### PR TITLE
Updated Naming Conventions

### DIFF
--- a/SvcScan/src/argex.cpp
+++ b/SvcScan/src/argex.cpp
@@ -10,29 +10,29 @@
 /// ***
 /// Initialize the object
 /// ***
-Scan::ArgEx::ArgEx(const char *argp, const string &msg) : base(msg)
+scan::ArgEx::ArgEx(const char *t_argp, const string &t_msg) : base(t_msg)
 {
-    if (argp == nullptr)
+    if (t_argp == nullptr)
     {
-        throw NullArgEx("argp");
+        throw NullArgEx("t_argp");
     }
-    this->arg = argp;
-    this->msg = msg;
+    arg = t_argp;
+    msg = t_msg;
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::ArgEx::ArgEx(const vector_s &vect, const string &msg) : base(msg)
+scan::ArgEx::ArgEx(const vector_s &t_vect, const string &t_msg) : base(t_msg)
 {
-    this->arg = List<string>::join(vect, ", ");
-    this->msg = msg;
+    arg = List<string>::join(t_vect, ", ");
+    msg = t_msg;
 }
 
 /// ***
 /// Cast operator overload
 /// ***
-Scan::ArgEx::operator const std::string() const
+scan::ArgEx::operator const std::string() const
 {
     const string header{ Util::fmt("----[ % ]----", name()) };
 
@@ -48,7 +48,7 @@ Scan::ArgEx::operator const std::string() const
 /// ***
 /// Cast operator overload
 /// ***
-Scan::ArgEx::operator std::string()
+scan::ArgEx::operator std::string()
 {
     const string header{ Util::fmt("----[ % ]----", name()) };
 
@@ -64,7 +64,7 @@ Scan::ArgEx::operator std::string()
 /// ***
 /// Print exception information to standard error
 /// ***
-void Scan::ArgEx::show() const
+void scan::ArgEx::show() const
 {
     Util::except(*this);
 }
@@ -72,7 +72,7 @@ void Scan::ArgEx::show() const
 /// ***
 /// Get the name of the exception
 /// ***
-const std::string Scan::ArgEx::name() const noexcept
+const std::string scan::ArgEx::name() const noexcept
 {
     return static_cast<string>(NAME);
 }

--- a/SvcScan/src/endpoint.cpp
+++ b/SvcScan/src/endpoint.cpp
@@ -8,25 +8,25 @@
 /// ***
 /// Initialize the object
 /// ***
-Scan::EndPoint::EndPoint(const EndPoint &ep)
+scan::EndPoint::EndPoint(const EndPoint &t_ep)
 {
-    this->addr = ep.addr;
-    this->port = ep.port;
+    addr = t_ep.addr;
+    port = t_ep.port;
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::EndPoint::EndPoint(const string &addr, const string &port)
+scan::EndPoint::EndPoint(const string &t_addr, const string &t_port)
 {
-    this->addr = addr;
-    this->port = port;
+    addr = t_addr;
+    port = t_port;
 }
 
 /// ***
 /// Cast operator overload
 /// ***
-Scan::EndPoint::operator const std::string() const
+scan::EndPoint::operator const std::string() const
 {
     return str(addr.get(), port.get());
 }
@@ -34,7 +34,7 @@ Scan::EndPoint::operator const std::string() const
 /// ***
 /// Format the endpoint as a string
 /// ***
-const std::string Scan::EndPoint::str(const string &addr,
-                                      const string &port) const {
-    return (addr + ":" + port);
+const std::string scan::EndPoint::str(const string &t_addr,
+                                      const string &t_port) const {
+    return (t_addr + ":" + t_port);
 }

--- a/SvcScan/src/includes/container/iterator.h
+++ b/SvcScan/src/includes/container/iterator.h
@@ -8,7 +8,7 @@
 #ifndef ITERATOR_H
 #define ITERATOR_H
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// Constant forward iterator for containers
@@ -29,8 +29,8 @@ namespace Scan
 
     public:  /* Constructors & Destructor */
         Iterator();
-        Iterator(const Iterator &it);
-        Iterator(const value_type *ptr);
+        Iterator(const Iterator &t_it);
+        Iterator(const value_type *t_ptr);
 
         virtual ~Iterator() = default;
 
@@ -40,14 +40,14 @@ namespace Scan
         const T *operator->() const;
         const T &operator*() const;
 
-        Iterator operator+(const size_t &idx) const;
-        Iterator operator+(const int &idx) const;
+        Iterator operator+(const size_t &t_idx) const;
+        Iterator operator+(const int &t_idx) const;
 
         Iterator &operator++();
         Iterator operator++(int);
 
-        const bool operator==(const Iterator &it) const noexcept;
-        const bool operator!=(const Iterator &it) const noexcept;
+        const bool operator==(const Iterator &t_it) const noexcept;
+        const bool operator!=(const Iterator &t_it) const noexcept;
     };
 }
 
@@ -55,34 +55,34 @@ namespace Scan
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::Iterator<T>::Iterator()
+inline scan::Iterator<T>::Iterator()
 {
-    this->m_ptr = nullptr;
+    m_ptr = nullptr;
 }
 
 /// ***
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::Iterator<T>::Iterator(const Iterator &it)
+inline scan::Iterator<T>::Iterator(const Iterator &t_it)
 {
-    this->m_ptr = it.m_ptr;
+    m_ptr = t_it.m_ptr;
 }
 
 /// ***
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::Iterator<T>::Iterator(const value_type *ptr)
+inline scan::Iterator<T>::Iterator(const value_type *t_ptr)
 {
-    this->m_ptr = ptr;
+    m_ptr = t_ptr;
 }
 
 /// ***
 /// Cast operator overload
 /// ***
 template<class T>
-inline Scan::Iterator<T>::operator const size_t() const
+inline scan::Iterator<T>::operator const size_t() const
 {
     return reinterpret_cast<size_t>(m_ptr);
 }
@@ -91,7 +91,7 @@ inline Scan::Iterator<T>::operator const size_t() const
 /// Dereference operator overload
 /// ***
 template<class T>
-inline const T *Scan::Iterator<T>::operator->() const
+inline const T *scan::Iterator<T>::operator->() const
 {
     return m_ptr;
 }
@@ -100,7 +100,7 @@ inline const T *Scan::Iterator<T>::operator->() const
 /// Indirection operator overload
 /// ***
 template<class T>
-inline const T &Scan::Iterator<T>::operator*() const
+inline const T &scan::Iterator<T>::operator*() const
 {
     return *m_ptr;
 }
@@ -109,25 +109,25 @@ inline const T &Scan::Iterator<T>::operator*() const
 /// Addition operator overload
 /// ***
 template<class T>
-inline Scan::Iterator<T> Scan::Iterator<T>::operator+(const size_t &idx) const
+inline scan::Iterator<T> scan::Iterator<T>::operator+(const size_t &t_idx) const
 {
-    return static_cast<Iterator>(m_ptr + idx);
+    return static_cast<Iterator>(m_ptr + t_idx);
 }
 
 /// ***
 /// Addition operator overload
 /// ***
 template<class T>
-inline Scan::Iterator<T> Scan::Iterator<T>::operator+(const int &idx) const
+inline scan::Iterator<T> scan::Iterator<T>::operator+(const int &t_idx) const
 {
-    return operator+(static_cast<size_t>(idx));
+    return operator+(static_cast<size_t>(t_idx));
 }
 
 /// ***
 /// Prefix increment operator overload
 /// ***
 template<class T>
-inline Scan::Iterator<T> &Scan::Iterator<T>::operator++()
+inline scan::Iterator<T> &scan::Iterator<T>::operator++()
 {
     m_ptr++;
     return *this;
@@ -137,9 +137,9 @@ inline Scan::Iterator<T> &Scan::Iterator<T>::operator++()
 /// Postfix increment operator overload
 /// ***
 template<class T>
-inline Scan::Iterator<T> Scan::Iterator<T>::operator++(int)
+inline scan::Iterator<T> scan::Iterator<T>::operator++(int)
 {
-    Iterator orig{ *this };
+    const Iterator orig{ *this };
     ++(*this);
     return orig;
 }
@@ -148,18 +148,18 @@ inline Scan::Iterator<T> Scan::Iterator<T>::operator++(int)
 /// Equality operator overload
 /// ***
 template<class T>
-inline const bool Scan::Iterator<T>::operator==(const Iterator &it) const
+inline const bool scan::Iterator<T>::operator==(const Iterator &t_it) const
 noexcept {
-    return m_ptr == it.m_ptr;
+    return m_ptr == t_it.m_ptr;
 }
 
 /// ***
 /// Inequality operator overload
 /// ***
 template<class T>
-inline const bool Scan::Iterator<T>::operator!=(const Iterator &it) const
+inline const bool scan::Iterator<T>::operator!=(const Iterator &t_it) const
 noexcept {
-    return m_ptr != it.m_ptr;
+    return m_ptr != t_it.m_ptr;
 }
 
 #endif // !ITERATOR_H

--- a/SvcScan/src/includes/container/list.h
+++ b/SvcScan/src/includes/container/list.h
@@ -14,7 +14,7 @@
 #include "../utils/util.h"
 #include "iterator.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// Generic container that encapsulates a vector
@@ -32,55 +32,54 @@ namespace Scan
         using vector_t = std::vector<value_type>;
 
     private:  /* Constants & Fields */
-        static constexpr char LF[]{ *Util::LF };
+        static constexpr char LF[]{ *Util::LF, '\0' };
 
         vector_t m_vect;  // Underlying vector
 
     public:  /* Constructors & Destructor */
         List() = default;
-        List(const List &list);
-        explicit List(const vector_t &vect);
+        List(const List &t_list);
+        explicit List(const vector_t &t_vect);
 
         virtual ~List() = default;
 
     public:  /* Operators */
         operator const vector_t() const noexcept;
 
-        T &operator[](const size_t &index);
-        List &operator=(const vector_t &vect) noexcept;
+        T &operator[](const size_t &t_idx);
+        List &operator=(const vector_t &t_vect) noexcept;
 
     public:  /* Methods */
-        static const bool contains(const vector_t &vect,
-                                   const value_type &elem);
+        static const bool contains(const vector_t &t_vect,
+                                   const value_type &t_elem);
 
-        static const string join(const vector_t &vect,
-                                 const string &delim = LF);
+        static const string join(const vector_t &t_vect,
+                                 const string &t_delim = LF);
 
-        void add(const value_type &elem);
-        void remove(const value_type &elem);
-        void remove(const size_t &offset);
+        void add(const value_type &t_elem);
+        void remove(const value_type &t_elem);
+        void remove(const size_t &t_offset);
 
-        const bool any(const vector_t &vect) const noexcept;
-        const bool contains(const value_type &elem) const noexcept;
+        const bool any(const vector_t &t_vect) const noexcept;
+        const bool contains(const value_type &t_elem) const noexcept;
         const bool empty() const noexcept;
 
-        const ptrdiff_t index_of(const value_type &elem) const noexcept;
+        const size_t index_of(const value_type &t_elem) const noexcept;
         const size_t size() const noexcept;
 
-        const string join(const string &delim = LF) const;
+        const string join(const string &t_delim = LF) const;
 
         typename iterator begin() const noexcept;
         typename iterator end() const noexcept;
 
-        const T &at(const size_t &index) const;
+        const T &at(const size_t &t_idx) const;
         const T last() const;
 
-        const List<T> slice(const iterator &beg_it,
-                            const iterator &end_it) const;
+        const List<T> slice(const iterator &t_beg, const iterator &t_end) const;
 
     private:  /* Methods */
-        const bool valid_index(const size_t &index) const;
-        const bool valid_index(const vector_st &vect) const;
+        const bool valid_index(const size_t &t_idx) const;
+        const bool valid_index(const vector_st &t_vect) const;
     };
 }
 
@@ -88,25 +87,25 @@ namespace Scan
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::List<T>::List(const List &list)
+inline scan::List<T>::List(const List &t_list)
 {
-    this->m_vect = list.m_vect;
+    m_vect = t_list.m_vect;
 }
 
 /// ***
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::List<T>::List(const vector_t &vect)
+inline scan::List<T>::List(const vector_t &t_vect)
 {
-    this->m_vect = vect;
+    m_vect = t_vect;
 }
 
 /// ***
 /// Cast operator overload
 /// ***
 template<class T>
-inline Scan::List<T>::operator const vector_t() const noexcept
+inline scan::List<T>::operator const vector_t() const noexcept
 {
     return static_cast<vector_t>(m_vect);
 }
@@ -115,22 +114,22 @@ inline Scan::List<T>::operator const vector_t() const noexcept
 /// Subscript operator overload
 /// ***
 template<class T>
-inline T &Scan::List<T>::operator[](const size_t &index)
+inline T &scan::List<T>::operator[](const size_t &t_idx)
 {
-    if (!valid_index(index))
+    if (!valid_index(t_idx))
     {
-        throw ArgEx("index", "Index out of vector bounds");
+        throw ArgEx("t_idx", "Index out of vector bounds");
     }
-    return static_cast<value_type &>(m_vect[index]);
+    return static_cast<value_type &>(m_vect[t_idx]);
 }
 
 /// ***
 /// Assignment operator overload
 /// ***
 template<class T>
-inline Scan::List<T> &Scan::List<T>::operator=(const vector_t &vect) noexcept
+inline scan::List<T> &scan::List<T>::operator=(const vector_t &t_vect) noexcept
 {
-    m_vect = vect;
+    m_vect = t_vect;
     return *this;
 }
 
@@ -138,41 +137,41 @@ inline Scan::List<T> &Scan::List<T>::operator=(const vector_t &vect) noexcept
 /// Utility method - Determine if vector contains the element
 /// ***
 template<class T>
-inline const bool Scan::List<T>::contains(const vector_t &vect,
-                                          const value_type &elem) {
-    return List(vect).contains(elem);
+inline const bool scan::List<T>::contains(const vector_t &t_vect,
+                                          const value_type &t_elem) {
+    return List(t_vect).contains(t_elem);
 }
 
 /// ***
 /// Utility method - Join vector elements by given delimiter
 /// ***
 template<class T>
-inline const std::string Scan::List<T>::join(const vector_t &vect,
-                                             const string &delim) {
-    return List(vect).join(delim);
+inline const std::string scan::List<T>::join(const vector_t &t_vect,
+                                             const string &t_delim) {
+    return List(t_vect).join(t_delim);
 }
 
 /// ***
 /// Add an element to the underlying vector
 /// ***
 template<class T>
-inline void Scan::List<T>::add(const value_type &elem)
+inline void scan::List<T>::add(const value_type &t_elem)
 {
-    m_vect.push_back(elem);
+    m_vect.push_back(t_elem);
 }
 
 /// ***
 /// Remove the first matching element in the underlying vector
 /// ***
 template<class T>
-inline void Scan::List<T>::remove(const value_type &elem)
+inline void scan::List<T>::remove(const value_type &t_elem)
 {
-    const ptrdiff_t offset{ index_of(elem) };
+    const ptrdiff_t offset{ static_cast<ptrdiff_t>(index_of(t_elem)) };
 
     // No matching element found
     if (offset < 0)
     {
-        throw ArgEx("elem", "No matching element found to remove");
+        throw ArgEx("t_elem", "No matching element found to remove");
     }
     remove(static_cast<size_t>(offset));
 }
@@ -181,15 +180,15 @@ inline void Scan::List<T>::remove(const value_type &elem)
 /// Remove vector element specified by the iterator
 /// ***
 template<class T>
-inline void Scan::List<T>::remove(const size_t &offset)
+inline void scan::List<T>::remove(const size_t &t_offset)
 {
     // Index out of vector bounds
-    if (offset >= size())
+    if (t_offset >= size())
     {
-        throw ArgEx("offset", "Index out of vector bounds");
+        throw ArgEx("t_offset", "Index out of vector bounds");
     }
 
-    m_vect.erase(m_vect.begin() + offset);
+    m_vect.erase(m_vect.begin() + t_offset);
     m_vect.shrink_to_fit();
 }
 
@@ -197,15 +196,15 @@ inline void Scan::List<T>::remove(const size_t &offset)
 /// Determine if underlying vector contains any of the given elements
 /// ***
 template<class T>
-inline const bool Scan::List<T>::any(const vector_t &vect) const noexcept
+inline const bool scan::List<T>::any(const vector_t &t_vect) const noexcept
 {
-    if (vect.empty())
+    if (t_vect.empty())
     {
         return false;
     }
 
     // Look for matching element
-    for (const value_type &elem : vect)
+    for (const value_type &elem : t_vect)
     {
         if (contains(elem))
         {
@@ -219,16 +218,16 @@ inline const bool Scan::List<T>::any(const vector_t &vect) const noexcept
 /// Determine if underlying vector contains the given element
 /// ***
 template<class T>
-inline const bool Scan::List<T>::contains(const value_type &elem) const noexcept
-{
-    return index_of(elem) != -1;
+inline const bool scan::List<T>::contains(const value_type &t_elem) const
+noexcept {
+    return index_of(t_elem) != -1;
 }
 
 /// ***
 /// Determine if underlying vector is empty
 /// ***
 template<class T>
-inline const bool Scan::List<T>::empty() const noexcept
+inline const bool scan::List<T>::empty() const noexcept
 {
     return m_vect.empty();
 }
@@ -237,23 +236,23 @@ inline const bool Scan::List<T>::empty() const noexcept
 /// Get the index of first matching element in the vector
 /// ***
 template<class T>
-inline const ptrdiff_t Scan::List<T>::index_of(const value_type &elem) const
+inline const size_t scan::List<T>::index_of(const value_type &t_elem) const
 noexcept {
     for (size_t i{ 0 }; i < size(); i++)
     {
-        if (m_vect[i] == elem)
+        if (m_vect[i] == t_elem)
         {
-            return static_cast<ptrdiff_t>(i);
+            return i;
         }
     }
-    return static_cast<ptrdiff_t>(-1);
+    return static_cast<size_t>(-1);
 }
 
 /// ***
 /// Get the current size of the underlying vector
 /// ***
 template<class T>
-inline const size_t Scan::List<T>::size() const noexcept
+inline const size_t scan::List<T>::size() const noexcept
 {
     return m_vect.size();
 }
@@ -262,7 +261,7 @@ inline const size_t Scan::List<T>::size() const noexcept
 /// Join current list elements by given separator (default: EOL)
 /// ***
 template<class T>
-inline const std::string Scan::List<T>::join(const string &delim) const
+inline const std::string scan::List<T>::join(const string &t_delim) const
 {
     string data;
 
@@ -274,7 +273,7 @@ inline const std::string Scan::List<T>::join(const string &delim) const
         // Don't append separator to last arg
         if (elem != last())
         {
-            data += delim;
+            data += t_delim;
         }
     }
     return data;
@@ -284,7 +283,7 @@ inline const std::string Scan::List<T>::join(const string &delim) const
 /// Get iterator to first element in underlying vector
 /// ***
 template<class T>
-inline typename Scan::List<T>::iterator Scan::List<T>::begin() const noexcept
+inline typename scan::List<T>::iterator scan::List<T>::begin() const noexcept
 {
     return static_cast<iterator>(m_vect.data());
 }
@@ -293,7 +292,7 @@ inline typename Scan::List<T>::iterator Scan::List<T>::begin() const noexcept
 /// Get iterator to past-the-end element in underlying vector
 /// ***
 template<class T>
-inline typename Scan::List<T>::iterator Scan::List<T>::end() const noexcept
+inline typename scan::List<T>::iterator scan::List<T>::end() const noexcept
 {
     return static_cast<iterator>(m_vect.data() + size());
 }
@@ -302,20 +301,20 @@ inline typename Scan::List<T>::iterator Scan::List<T>::end() const noexcept
 /// Get element reference at the given index
 /// ***
 template<class T>
-inline const T &Scan::List<T>::at(const size_t &index) const
+inline const T &scan::List<T>::at(const size_t &t_idx) const
 {
-    if (!valid_index(index))
+    if (!valid_index(t_idx))
     {
-        throw ArgEx("index", "Index out of vector bounds");
+        throw ArgEx("t_idx", "Index out of vector bounds");
     }
-    return m_vect.at(index);
+    return m_vect.at(t_idx);
 }
 
 /// ***
 /// Get the last element in the underlying vector
 /// ***
 template<class T>
-inline const T Scan::List<T>::last() const
+inline const T scan::List<T>::last() const
 {
     return empty() ? value_type() : m_vect.at(size() - 1);
 }
@@ -324,12 +323,12 @@ inline const T Scan::List<T>::last() const
 /// Retrieve a range of elements from the underlying vector
 /// ***
 template<class T>
-inline const Scan::List<T> Scan::List<T>::slice(const iterator &beg_it,
-                                                const iterator &end_it) const {
+inline const scan::List<T> scan::List<T>::slice(const iterator &t_beg,
+                                                const iterator &t_end) const {
     List range;
 
     // Add elements to the range
-    for (iterator it(beg_it); it != end_it; it++)
+    for (iterator it{ t_beg }; it != t_end; ++it)
     {
         range.add(*it);
     }
@@ -340,21 +339,21 @@ inline const Scan::List<T> Scan::List<T>::slice(const iterator &beg_it,
 /// Determine if index is valid for the underlying vector
 /// ***
 template<class T>
-inline const bool Scan::List<T>::valid_index(const size_t &index) const
+inline const bool scan::List<T>::valid_index(const size_t &t_idx) const
 {
-    return (index >= 0) && (index < size());
+    return (t_idx >= 0) && (t_idx < size());
 }
 
 /// ***
 /// Determine if index is valid for the underlying vector
 /// ***
 template<class T>
-inline const bool Scan::List<T>::valid_index(const vector_st &vect) const
+inline const bool scan::List<T>::valid_index(const vector_st &t_vect) const
 {
     // Validate each index in vector
-    for (const size_t &index : vect)
+    for (const size_t &idx : t_vect)
     {
-        if (!valid_index(index))
+        if (!valid_index(idx))
         {
             return false;
         }

--- a/SvcScan/src/includes/container/record.h
+++ b/SvcScan/src/includes/container/record.h
@@ -16,7 +16,7 @@
 #include "svcfield.h"
 #include "list.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// Service information table record (row)
@@ -41,9 +41,9 @@ namespace Scan
 
     public:  /* Constructors & Destructor */
         Record() = default;
-        Record(const Record &row);
-        explicit Record(const array_s &fields);
-        explicit Record(const SvcInfo &si);
+        Record(const Record &t_row);
+        explicit Record(const array_s &t_fields);
+        explicit Record(const SvcInfo &t_si);
 
         virtual ~Record() = default;
 
@@ -52,19 +52,19 @@ namespace Scan
         operator const std::string() const;
         operator const vector_s() const;
 
-        const bool operator==(const Record &row) const;
-        const bool operator!=(const Record &row) const;
+        const bool operator==(const Record &t_row) const;
+        const bool operator!=(const Record &t_row) const;
 
     public:  /* Methods */
-        static const bool is_less(const Record &lhs, const Record &rhs);
+        static const bool is_less(const Record &t_lhs, const Record &t_rhs);
 
-        void set_field(const SvcField &sf, const string &value);
+        void set_field(const SvcField &t_sf, const string &t_value);
 
-        const string get_field(const SvcField &sf) const;
-        const Record pad_fields(const map_sf<size_t> &dict) const;
+        const string get_field(const SvcField &t_sf) const;
+        const Record pad_fields(const map_sf<size_t> &t_dict) const;
 
     private:  /* Methods */
-        const string state_str(const HostState &hs) const noexcept;
+        const string state_str(const HostState &t_hs) const noexcept;
     };
 }
 

--- a/SvcScan/src/includes/container/svctable.h
+++ b/SvcScan/src/includes/container/svctable.h
@@ -15,7 +15,7 @@
 #include "record.h"
 #include "svcfield.h"
 
-namespace Scan
+namespace scan
 {
     class SvcTable
     {
@@ -24,7 +24,6 @@ namespace Scan
 
         using list_r = List<Record>;
         using vector_r = std::vector<Record>;
-        using vector_s = std::vector<string>;
         using vector_si = std::vector<SvcInfo>;
 
         template<class T>
@@ -35,8 +34,8 @@ namespace Scan
         list_r m_list;  // Record list
 
     public:  /* Constructors & Destructor */
-        SvcTable(const SvcTable &st);
-        SvcTable(const string &addr, const vector_si &vect);
+        SvcTable(const SvcTable &t_st);
+        SvcTable(const string &t_addr, const vector_si &t_vect);
 
         virtual ~SvcTable() = default;
 
@@ -44,26 +43,32 @@ namespace Scan
         SvcTable();
 
     public:  /* Operators */
-        const Record operator[](const size_t &index) const;
+        const Record operator[](const size_t &t_idx) const;
 
-        friend std::ostream &operator<<(std::ostream &os, const SvcTable &st);
+        friend std::ostream &operator<<(std::ostream &t_os,
+                                        const SvcTable &t_st);
 
     public:  /* Methods */
-        void add(const SvcInfo &si);
-        void add(const vector_si &vect);
+        void add(const SvcInfo &t_si);
+        void add(const vector_si &t_vect);
 
         const string str() const;
 
     private:  /* Methods */
-        const int field_width(const vector_r &vect, const SvcField &sf) const;
+        const int field_width(const vector_r &t_vect,
+                              const SvcField &t_sf) const;
     };
 
     /// ***
     /// Bitwise left shift operator overload
     /// ***
-    inline std::ostream &operator<<(std::ostream &os, const SvcTable &st)
+    inline std::ostream &operator<<(std::ostream &t_os, const SvcTable &t_st)
     {
-        return (os << st.str());
+        if (Parser::verbose.get())
+        {
+            t_os << Util::LF;
+        }
+        return (t_os << t_st.str());
     }
 }
 

--- a/SvcScan/src/includes/except/argex.h
+++ b/SvcScan/src/includes/except/argex.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include "../properties/autoprop.h"
 
-namespace Scan
+namespace scan
 {
     class ArgEx : public std::invalid_argument
     {
@@ -22,7 +22,8 @@ namespace Scan
 
     private:  /* Types & Constants */
         using base = std::invalid_argument;
-        static constexpr char NAME[] = "SvcScan::Scan::ArgEx";
+
+        static constexpr char NAME[] = "SvcScan::scan::ArgEx";
 
     public:  /* Fields */
         AutoProp<string> arg;  // Invalid argument
@@ -30,8 +31,8 @@ namespace Scan
 
     public:  /* Constructors & Destructor */
         ArgEx(const ArgEx &) = default;
-        ArgEx(const char *argp, const string &msg);
-        ArgEx(const vector_s &vect, const string &msg);
+        ArgEx(const char *t_argp, const string &t_msg);
+        ArgEx(const vector_s &t_vect, const string &t_msg);
 
         virtual ~ArgEx() = default;
 
@@ -42,7 +43,7 @@ namespace Scan
         operator const std::string() const;
         operator std::string();
 
-        friend std::ostream &operator<<(std::ostream &os, const ArgEx &ex);
+        friend std::ostream &operator<<(std::ostream &t_os, const ArgEx &t_ex);
 
     public:  /* Methods */
         virtual void show() const;
@@ -53,9 +54,9 @@ namespace Scan
     /// ***
     /// Bitwise left shift operator overload
     /// ***
-    inline std::ostream &operator<<(std::ostream &os, const ArgEx &ex)
+    inline std::ostream &operator<<(std::ostream &t_os, const ArgEx &t_ex)
     {
-        return (os << static_cast<std::string>(ex));
+        return (t_os << static_cast<std::string>(t_ex));
     }
 }
 

--- a/SvcScan/src/includes/except/nullargex.h
+++ b/SvcScan/src/includes/except/nullargex.h
@@ -10,7 +10,7 @@
 
 #include "argex.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// Null argument exception
@@ -19,23 +19,24 @@ namespace Scan
     {
     private:  /* Types & Constants */
         using base = ArgEx;
-        static constexpr char NAME[] = "SvcScan::Scan::NullArgEx";
+        static constexpr char NAME[] = "SvcScan::scan::NullArgEx";
 
     public:  /* Constructors & Destructor */
         NullArgEx(const NullArgEx &) = default;
-        explicit NullArgEx(const char *arg_ptr);
-        explicit NullArgEx(const vector_s &vect);
+        explicit NullArgEx(const char *t_arg_ptr);
+        explicit NullArgEx(const vector_s &t_vect);
 
         virtual ~NullArgEx() = default;
 
     protected:  /* Constructors */
-        NullArgEx(const vector_s &vect, const std::string &msg);
+        NullArgEx(const vector_s &t_vect, const std::string &t_msg);
 
     private:  /* Constructors (deleted) */
         NullArgEx() = delete;
 
     public:  /* Operators */
-        friend std::ostream &operator<<(std::ostream &os, const NullArgEx &ex);
+        friend std::ostream &operator<<(std::ostream &t_os,
+                                        const NullArgEx &t_ex);
 
     public:  /* Methods */
         virtual void show() const override;
@@ -48,9 +49,9 @@ namespace Scan
     /// ***
     /// Bitwise left shift operator overload
     /// ***
-    inline std::ostream &operator<<(std::ostream &os, const NullArgEx &ex)
+    inline std::ostream &operator<<(std::ostream &t_os, const NullArgEx &t_ex)
     {
-        return (os << static_cast<std::string>(ex));
+        return (t_os << static_cast<std::string>(t_ex));
     }
 }
 

--- a/SvcScan/src/includes/except/nullptrex.h
+++ b/SvcScan/src/includes/except/nullptrex.h
@@ -10,7 +10,7 @@
 
 #include "nullargex.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// Null pointer argument exception
@@ -19,17 +19,18 @@ namespace Scan
     {
     private:  /* Types & Constants */
         using base = NullArgEx;
-        static constexpr char NAME[] = "SvcScan::Scan::NullPtrEx";
+        static constexpr char NAME[] = "SvcScan::scan::NullPtrEx";
 
     public:  /* Constructors & Destructor */
         NullPtrEx(const NullPtrEx &) = default;
-        explicit NullPtrEx(const char *argp);
-        explicit NullPtrEx(const vector_s &vect);
+        explicit NullPtrEx(const char *t_argp);
+        explicit NullPtrEx(const vector_s &t_vect);
 
         virtual ~NullPtrEx() = default;
 
     public:  /* Operators */
-        friend std::ostream &operator<<(std::ostream &os, const NullPtrEx &ex);
+        friend std::ostream &operator<<(std::ostream &t_os,
+                                        const NullPtrEx &t_ex);
 
     public:  /* Methods */
         virtual void show() const override;
@@ -42,9 +43,9 @@ namespace Scan
     /// ***
     /// Bitwise left shift operator overload
     /// ***
-    inline std::ostream &operator<<(std::ostream &os, const NullPtrEx &ex)
+    inline std::ostream &operator<<(std::ostream &t_os, const NullPtrEx &t_ex)
     {
-        return (os << static_cast<std::string>(ex));
+        return (t_os << static_cast<std::string>(t_ex));
     }
 }
 

--- a/SvcScan/src/includes/net/endpoint.h
+++ b/SvcScan/src/includes/net/endpoint.h
@@ -11,7 +11,7 @@
 #include <string>
 #include "../properties/autoprop.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// IPv4 TCP connection endpoint
@@ -27,26 +27,27 @@ namespace Scan
 
     public:  /* Constructors & Destructor */
         EndPoint() = default;
-        EndPoint(const EndPoint &ep);
-        EndPoint(const string &addr, const string &port);
+        EndPoint(const EndPoint &t_ep);
+        EndPoint(const string &t_addr, const string &t_port);
 
         virtual ~EndPoint() = default;
 
     public:  /* Operators */
         operator const std::string() const;
 
-        friend std::ostream &operator<<(std::ostream &os, const EndPoint &ep);
+        friend std::ostream &operator<<(std::ostream &t_os,
+                                        const EndPoint &t_ep);
 
     private:  /* Methods */
-        const string str(const string &addr, const string &port) const;
+        const string str(const string &t_addr, const string &t_port) const;
     };
 
     /// ***
     /// Bitwise left shift operator overload
     /// ***
-    inline std::ostream &operator<<(std::ostream &os, const EndPoint &ep)
+    inline std::ostream &operator<<(std::ostream &t_os, const EndPoint &t_ep)
     {
-        return (os << ep.addr << ":" << ep.port);
+        return (t_os << t_ep.addr << ":" << t_ep.port);
     }
 }
 

--- a/SvcScan/src/includes/net/socket.h
+++ b/SvcScan/src/includes/net/socket.h
@@ -25,7 +25,7 @@
 #include "../utils/util.h"
 #include "svcinfo.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// Windows IPv4 TCP network socket wrapper
@@ -42,7 +42,6 @@ namespace Scan
         using list_s = List<string>;
         using list_si = List<SvcInfo>;
         using vector_s = std::vector<string>;
-        using vector_ul = std::vector<ulong>;
 
         using property_l = Property<list_s>;
         using property_s = Property<string>;
@@ -64,44 +63,47 @@ namespace Scan
 
     public:  /* Constructors & Destructor */
         Socket();
-        Socket(const Socket &sock);
-        Socket(const property_s &addr, const property_l &ports);
+        Socket(const Socket &t_sock);
+        Socket(const property_s &t_addr, const property_l &t_ports);
 
         virtual ~Socket();
 
     public:  /* Operators */
-        Socket &operator=(const Socket &sock) noexcept;
+        Socket &operator=(const Socket &t_sock) noexcept;
 
     public:  /* Methods */
-        static const bool valid_port(const string &port);
-        static const bool valid_port(const vector_s &ports);
+        static const bool valid_port(const string &t_port);
+        static const bool valid_port(const vector_s &t_ports);
 
-        static const int valid_ip(const string &addr);
+        static const int valid_ip(const string &t_addr);
 
         void connect();
 
     private:  /* Methods */
-        void close(addrinfoW *ai_ptr);
+        void close(addrinfoW *t_aiptr);
         void error() const;
-        void error(const int &err) const;
-        void error(const string &arg) const;
-        void error(const int &err, const string &arg) const;
+        void error(const int &t_err) const;
+        void error(const string &t_arg) const;
+        void error(const int &t_err, const string &arg) const;
 
-        const bool valid_sock(const SOCKET &sock) const noexcept;
+        const bool valid_sock(const SOCKET &t_sock) const noexcept;
 
-        const HostState connect(addrinfoW *ai_ptr, char (&buffer)[BUFFER_SIZE],
-                                                   const EndPoint &ep);
+        const HostState connect(addrinfoW *t_aiptr,
+                                char (&t_buffer)[BUFFER_SIZE],
+                                const EndPoint &t_ep);
+
         const int get_error() const;
 
-        const int select(fd_set *rfds_ptr, fd_set *wfds_ptr,
-                                           const timeval &to = { 0, 1 }) const;
+        const int select(fd_set *t_rfds_ptr,
+                         fd_set *t_wfds_ptr,
+                         const timeval &t_to = { 0, 1 }) const;
 
-        const int set_blocking(const bool &do_block);
+        const int set_blocking(const bool &t_do_block);
 
-        addrinfoW *startup(SvcInfo &si, const string &port);
+        addrinfoW *startup(SvcInfo &t_si, const string &t_port);
 
-        SvcInfo &update_svc(SvcInfo &si, const string &port,
-                                         const HostState &hs) const;
+        SvcInfo &update_svc(SvcInfo &t_si, const string &t_port,
+                                           const HostState &t_hs) const;
     };
 }
 

--- a/SvcScan/src/includes/net/svcinfo.h
+++ b/SvcScan/src/includes/net/svcinfo.h
@@ -16,7 +16,7 @@
 #include "endpoint.h"
 #include "hoststate.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// TCP network application service information
@@ -38,24 +38,24 @@ namespace Scan
 
     public:  /* Constructors & Destructor */
         SvcInfo() = default;
-        SvcInfo(const SvcInfo &si);
-        SvcInfo(const EndPoint &ep, const HostState &hs = HostState::unknown);
+        SvcInfo(const SvcInfo &t_si);
+        SvcInfo(const EndPoint &ep, const HostState &t_hs = HostState::unknown);
 
-        SvcInfo(const EndPoint &ep, const string &banner,
-                                    const HostState &hs = HostState::open);
+        SvcInfo(const EndPoint &t_ep, const string &t_banner,
+                                      const HostState &t_hs = HostState::open);
 
         virtual ~SvcInfo() = default;
 
     public:  /* Operators */
-        SvcInfo &operator=(const SvcInfo &si) noexcept;
+        SvcInfo &operator=(const SvcInfo &t_si) noexcept;
 
     public:  /* Methods */
-        void parse(const string &banner_txt);
+        void parse(const string &t_banner);
 
     private:  /* Methods */
-        const string upto_eol(const string &data) const;
+        const string upto_eol(const string &t_data) const;
 
-        SvcInfo &swap(const SvcInfo &si) noexcept;
+        SvcInfo &swap(const SvcInfo &t_si) noexcept;
     };
 }
 

--- a/SvcScan/src/includes/properties/autoprop.h
+++ b/SvcScan/src/includes/properties/autoprop.h
@@ -11,7 +11,7 @@
 
 #include "property.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// Property that automatically encapsulates
@@ -29,28 +29,28 @@ namespace Scan
 
     public:  /* Constructors & Destructor */
         AutoProp();
-        AutoProp(const AutoProp &ap);
-        explicit AutoProp(const value_type &val);
+        AutoProp(const AutoProp &t_ap);
+        explicit AutoProp(const value_type &t_val);
 
         virtual ~AutoProp() = default;
 
     public:  /* Operators */
-        AutoProp &operator=(const value_type &val) noexcept;
-        AutoProp &operator=(const AutoProp &ap) noexcept;
+        AutoProp &operator=(const value_type &t_val) noexcept;
+        AutoProp &operator=(const AutoProp &t_ap) noexcept;
 
-        T operator+(const value_type &val) const;
+        T operator+(const value_type &t_val) const;
 
-        AutoProp &operator+=(const value_type &val);
-        AutoProp &operator+=(const AutoProp &ap);
+        AutoProp &operator+=(const value_type &t_val);
+        AutoProp &operator+=(const AutoProp &t_ap);
 
         /// Bitwise left shift operator overload
-        inline friend std::ostream &operator<<(std::ostream &os,
-                                               const AutoProp &ap) {
-            return (os << ap.get());
+        inline friend std::ostream &operator<<(std::ostream &t_os,
+                                               const AutoProp &t_ap) {
+            return (t_os << t_ap.get());
         };
 
     public:  /* Methods */
-        void set(const value_type &val);
+        void set(const value_type &t_val);
 
         const typename base::value_type get() const override;
         typename base::value_type get() override;
@@ -61,9 +61,9 @@ namespace Scan
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::AutoProp<T>::AutoProp()
+inline scan::AutoProp<T>::AutoProp()
 {
-    this->m_value = value_type();
+    m_value = value_type();
     this->m_ptr = static_cast<value_type *>(&m_value);
 }
 
@@ -71,9 +71,9 @@ inline Scan::AutoProp<T>::AutoProp()
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::AutoProp<T>::AutoProp(const AutoProp &ap)
+inline scan::AutoProp<T>::AutoProp(const AutoProp &t_ap)
 {
-    this->m_value = ap.m_value;
+    m_value = t_ap.m_value;
     this->m_ptr = static_cast<value_type *>(&m_value);
 }
 
@@ -81,9 +81,9 @@ inline Scan::AutoProp<T>::AutoProp(const AutoProp &ap)
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::AutoProp<T>::AutoProp(const value_type &val)
+inline scan::AutoProp<T>::AutoProp(const value_type &t_val)
 {
-    this->m_value = val;
+    m_value = t_val;
     this->m_ptr = static_cast<value_type *>(&m_value);
 }
 
@@ -91,9 +91,9 @@ inline Scan::AutoProp<T>::AutoProp(const value_type &val)
 /// Assignment operator overload
 /// ***
 template<class T>
-inline Scan::AutoProp<T> &Scan::AutoProp<T>::operator=(const value_type &val)
+inline scan::AutoProp<T> &scan::AutoProp<T>::operator=(const value_type &t_val)
 noexcept {
-    m_value = val;
+    m_value = t_val;
     this->m_ptr = static_cast<value_type *>(&m_value);
 
     return *this;
@@ -103,9 +103,9 @@ noexcept {
 /// Assignment operator overload
 /// ***
 template<class T>
-inline Scan::AutoProp<T> &Scan::AutoProp<T>::operator=(const AutoProp &ap)
+inline scan::AutoProp<T> &scan::AutoProp<T>::operator=(const AutoProp &t_ap)
 noexcept {
-    m_value = ap.get();
+    m_value = t_ap.get();
     this->m_ptr = static_cast<value_type *>(&m_value);
 
     return *this;
@@ -115,18 +115,18 @@ noexcept {
 /// Addition operator overload
 /// ***
 template<class T>
-inline T Scan::AutoProp<T>::operator+(const value_type &val) const
+inline T scan::AutoProp<T>::operator+(const value_type &t_val) const
 {
-    return static_cast<value_type>(m_value + static_cast<value_type>(val));
+    return static_cast<value_type>(m_value + static_cast<value_type>(t_val));
 }
 
 /// ***
 /// Compound assignment operator overload
 /// ***
 template<class T>
-inline Scan::AutoProp<T> &Scan::AutoProp<T>::operator+=(const value_type &val)
+inline scan::AutoProp<T> &scan::AutoProp<T>::operator+=(const value_type &t_val)
 {
-    m_value = operator+(val);
+    m_value = operator+(t_val);
     this->m_ptr = static_cast<value_type *>(&m_value);
 
     return *this;
@@ -136,28 +136,28 @@ inline Scan::AutoProp<T> &Scan::AutoProp<T>::operator+=(const value_type &val)
 /// Compound assignment operator overload
 /// ***
 template<class T>
-inline Scan::AutoProp<T> &Scan::AutoProp<T>::operator+=(const AutoProp &ap)
+inline scan::AutoProp<T> &scan::AutoProp<T>::operator+=(const AutoProp &t_ap)
 {
-    m_value = operator+(ap.get());
+    m_value = operator+(t_ap.get());
     this->m_ptr = static_cast<value_type *>(&m_value);
 
-    return operator+=(ap.get());
+    return operator+=(t_ap.get());
 }
 
 /// ***
 /// Backing field object specifier
 /// ***
 template<class T>
-inline void Scan::AutoProp<T>::set(const value_type &val)
+inline void scan::AutoProp<T>::set(const value_type &t_val)
 {
-    operator=(val);
+    operator=(t_val);
 }
 
 /// ***
 /// Backing field object accessor
 /// ***
 template<class T>
-inline const typename Scan::AutoProp<T>::value_type Scan::AutoProp<T>::get()
+inline const typename scan::AutoProp<T>::value_type scan::AutoProp<T>::get()
 const {
     return static_cast<value_type>(m_value);
 }
@@ -166,7 +166,7 @@ const {
 /// Backing field object accessor
 /// ***
 template<class T>
-inline typename Scan::AutoProp<T>::value_type Scan::AutoProp<T>::get()
+inline typename scan::AutoProp<T>::value_type scan::AutoProp<T>::get()
 {
     return static_cast<value_type>(m_value);
 }

--- a/SvcScan/src/includes/properties/property.h
+++ b/SvcScan/src/includes/properties/property.h
@@ -11,7 +11,7 @@
 
 #include <iostream>
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// Property that encapsulates a backing field
@@ -27,29 +27,29 @@ namespace Scan
 
     public:  /* Constructors & Destructor */
         Property();
-        Property(const Property &prop);
-        explicit Property(const value_type *ptr);
+        Property(const Property &t_prop);
+        explicit Property(const value_type *t_ptr);
 
         virtual ~Property() = default;
 
     public:  /* Operators */
         const bool operator!() const noexcept;
 
-        Property &operator=(const value_type *ptr) noexcept;
-        Property &operator=(const Property &prop) noexcept;
+        Property &operator=(const value_type *t_ptr) noexcept;
+        Property &operator=(const Property &t_prop) noexcept;
 
         /// Bitwise left shift operator overload
-        inline friend std::ostream &operator<<(std::ostream &os,
-                                               const Property &prop) {
-            if (prop.get() == value_type())
+        inline friend std::ostream &operator<<(std::ostream &t_os,
+                                               const Property &t_prop) {
+            if (t_prop.get() == value_type())
             {
-                return os;
+                return t_os;
             }
-            return (os << prop.get());
+            return (t_os << t_prop.get());
         };
 
     public:  /* Methods */
-        virtual void set(const value_type *ptr) noexcept;
+        virtual void set(const value_type *t_ptr) noexcept;
 
         virtual const typename value_type get() const;
         virtual typename value_type get();
@@ -60,45 +60,45 @@ namespace Scan
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::Property<T>::Property()
+inline scan::Property<T>::Property()
 {
-    this->m_ptr = nullptr;
+    m_ptr = nullptr;
 }
 
 /// ***
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::Property<T>::Property(const Property &prop)
+inline scan::Property<T>::Property(const Property &t_prop)
 {
-    this->m_ptr = prop.m_ptr;
+    m_ptr = t_prop.m_ptr;
 }
 
 /// ***
 /// Initialize the object
 /// ***
 template<class T>
-inline Scan::Property<T>::Property(const value_type *ptr)
+inline scan::Property<T>::Property(const value_type *t_ptr)
 {
-    this->m_ptr = ptr ? ptr : nullptr;
+    m_ptr = t_ptr ? t_ptr : nullptr;
 }
 
 /// ***
 /// Logical (unary) NOT operator overload
 /// ***
 template<class T>
-inline const bool Scan::Property<T>::operator!() const noexcept
+inline const bool scan::Property<T>::operator!() const noexcept
 {
-    return (m_ptr == nullptr);
+    return m_ptr == nullptr;
 }
 
 /// ***
 /// Assignment operator overload
 /// ***
 template<class T>
-inline Scan::Property<T> &Scan::Property<T>::operator=(const value_type *ptr)
+inline scan::Property<T> &scan::Property<T>::operator=(const value_type *t_ptr)
 noexcept {
-    m_ptr = ptr ? ptr : nullptr;
+    m_ptr = t_ptr ? t_ptr : nullptr;
     return *this;
 }
 
@@ -106,9 +106,9 @@ noexcept {
 /// Assignment operator overload
 /// ***
 template<class T>
-inline Scan::Property<T> &Scan::Property<T>::operator=(const Property &prop)
+inline scan::Property<T> &scan::Property<T>::operator=(const Property &t_prop)
 noexcept {
-    m_ptr = prop.m_ptr;
+    m_ptr = t_prop.m_ptr;
     return *this;
 }
 
@@ -116,16 +116,16 @@ noexcept {
 /// Backing field object value specifier
 /// ***
 template<class T>
-inline void Scan::Property<T>::set(const value_type *ptr) noexcept
+inline void scan::Property<T>::set(const value_type *t_ptr) noexcept
 {
-    m_ptr = ptr ? ptr : nullptr;
+    m_ptr = t_ptr ? t_ptr : nullptr;
 }
 
 /// ***
 /// Backing field object value accessor
 /// ***
 template<class T>
-inline const typename Scan::Property<T>::value_type Scan::Property<T>::get()
+inline const typename scan::Property<T>::value_type scan::Property<T>::get()
 const {
     if (m_ptr == nullptr)
     {
@@ -138,7 +138,7 @@ const {
 /// Backing field object value accessor
 /// ***
 template<class T>
-inline typename Scan::Property<T>::value_type Scan::Property<T>::get()
+inline typename scan::Property<T>::value_type scan::Property<T>::get()
 {
     if (m_ptr == nullptr)
     {

--- a/SvcScan/src/includes/utils/parser.h
+++ b/SvcScan/src/includes/utils/parser.h
@@ -14,7 +14,7 @@
 #include "../properties/autoprop.h"
 #include "util.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// Command-line argument parser and validator
@@ -31,7 +31,7 @@ namespace Scan
         using vector_s = std::vector<string>;
 
         static constexpr char EXE[] = "svcscan.exe";
-        static constexpr char LF[]{ *Util::LF };
+        static constexpr char LF[]{ *Util::LF, '\0' };
 
     public:  /* Fields */
         static AutoProp<bool> verbose;  // Verbose output
@@ -43,14 +43,14 @@ namespace Scan
         Property<list_s> ports;         // Target ports
 
     private:  /* Fields */
-        string m_addr;        // 'addr' backing field
-        string m_usage;       // Program usage
+        string m_addr;   // 'addr' backing field
+        string m_usage;  // Program usage
 
-        list_s m_argv;        // Cmd-line arguments
-        list_s m_ports;       // 'ports' backing field
+        list_s m_argv;   // Cmd-line arguments
+        list_s m_ports;  // 'ports' backing field
 
     public:  /* Constructors & Destructor */
-        Parser(const int &argc, const char *argv[]);
+        Parser(const int &t_argc, const char *t_argv[]);
         virtual ~Parser() = default;
 
     private:  /* Constructors (deleted) */
@@ -61,14 +61,14 @@ namespace Scan
         void help();
 
     private:  /* Methods */
-        void error(const string &arg, const ArgType &arg_type) const;
-        void errorf(const string &msg, const string &arg) const;
-        void parse(const uint &argc, const char *argv[]);
-        void validate(list_s &list);
+        void error(const string &t_arg, const ArgType &t_arg_type) const;
+        void errorf(const string &t_msg, const string &t_arg) const;
+        void parse(const uint &t_argc, const char *t_argv[]);
+        void validate(list_s &t_list);
 
-        const bool parse_aliases(list_s &list);
-        const bool parse_flags(list_s &list);
-        const bool parse_ports(const string &ports);
+        const bool parse_aliases(list_s &t_list);
+        const bool parse_flags(list_s &t_list);
+        const bool parse_ports(const string &t_ports);
     };
 }
 

--- a/SvcScan/src/includes/utils/util.h
+++ b/SvcScan/src/includes/utils/util.h
@@ -15,7 +15,7 @@
 #include "../except/nullargex.h"
 #include "../properties/autoprop.h"
 
-namespace Scan
+namespace scan
 {
     /// ***
     /// String and standard stream manipulation utilities
@@ -36,9 +36,9 @@ namespace Scan
         using vector_s = std::vector<string>;
 
     public:  /* Constants */
-        static constexpr char CR[] = "\r";         // Carriage-return
-        static constexpr char LF[] = "\n";         // Unix EOL (line feed)
-        static constexpr char CRLF[]{ *CR, *LF };  // NT EOL (CR-LF)
+        static constexpr char CR[] = "\r";               // Carriage-return
+        static constexpr char LF[] = "\n";               // Unix EOL (LF)
+        static constexpr char CRLF[]{ *CR, *LF, '\0' };  // NT EOL (CR-LF)
 
     private:  /* Constants */
         static constexpr char RESET[] = "\033[0m";  // Ansi reset sequence
@@ -62,42 +62,44 @@ namespace Scan
         Util(const Util &) = delete;
 
     public:  /* Methods */
-        static void error(const string &msg);
-        static void errorf(const string &msg, const string &arg);
-        static void except(const ArgEx &ex);
-        static void print(const string &msg);
-        static void printf(const string &msg, const string &arg);
-        static void warn(const string &msg);
+        static void error(const string &t_msg);
+        static void errorf(const string &t_msg, const string &t_arg);
+        static void except(const ArgEx &t_ex);
+        static void print(const string &t_msg);
+        static void printf(const string &t_msg, const string &t_arg);
+        static void warn(const string &t_msg);
 
         static const int enable_vt();
 
-        static const size_t count(const string &str, const char &ch);
-        static const char *itoc(const llong &num);
+        static const size_t count(const string &t_str, const char &t_ch);
+        static const char *itoc(const llong &t_num);
 
-        static const vector_s split(const string &data, const string &delim);
+        static const vector_s split(const string &t_data,
+                                    const string &t_delim);
 
-        static const vector_s split(const string &data,
-                                    const string &delim,
-                                    const size_t &max_split);
+        static const vector_s split(const string &t_data,
+                                    const string &t_delim,
+                                    const size_t &t_max_split);
         template<class T>
-        static const string fmt(const string &msg, const T &arg);
+        static const string fmt(const string &t_msg, const T &t_arg);
 
-        static const string indent(const string &data,
-                                   const uint &tab_size = 4,
-                                   const bool skip_first = false);
+        static const string indent(const uint &t_size,
+                                   const string &t_data,
+                                   const bool t_skip_first = false);
 
-        static const string itos(const llong &num);
+        static const string itos(const llong &t_num);
 
-        static const string strip(const string &data, const char &match_ch,
-                                                      const bool &space = true);
+        static const string strip(const string &t_data,
+                                  const char &t_ch,
+                                  const bool &t_space = true);
 
-        static const string to_lower(const string &data);
-        static const string utf8(const wstring &data_w);
+        static const string to_lower(const string &t_data);
+        static const string utf8(const wstring &t_wdata);
 
-        static const wstring utf16(const string &data);
+        static const wstring utf16(const string &t_data);
 
     private:  /* Methods */
-        static void print(const FgColor &fg, const string &msg);
+        static void print(const FgColor &t_fg, const string &t_msg);
     };
 }
 
@@ -105,18 +107,18 @@ namespace Scan
 /// Interpolate string with argument at '%' position(s)
 /// ***
 template<class T>
-inline const std::string Scan::Util::fmt(const string &msg, const T &arg)
+inline const std::string scan::Util::fmt(const string &t_msg, const T &t_arg)
 {
-    if (msg.find('%') == -1)
+    if (t_msg.find('%') == -1)
     {
-        throw ArgEx("msg", "Missing format char: '%'");
+        throw ArgEx("t_msg", "Missing format char: '%'");
     }
     std::stringstream ss;
 
     // Populate stringstream data
-    for (int i{ 0 }; i < msg.length(); i++)
+    for (int i{ 0 }; i < t_msg.length(); i++)
     {
-        (msg[i] == '%') ? (ss << arg) : (ss << msg[i]);
+        (t_msg[i] == '%') ? (ss << t_arg) : (ss << t_msg[i]);
     }
     return ss.str();
 }

--- a/SvcScan/src/nullargex.cpp
+++ b/SvcScan/src/nullargex.cpp
@@ -9,28 +9,28 @@
 /// ***
 /// Initialize the object
 /// ***
-Scan::NullArgEx::NullArgEx(const char *arg_ptr)
-    : base(arg_ptr, init_msg()) {
+scan::NullArgEx::NullArgEx(const char *t_arg_ptr)
+    : base(t_arg_ptr, init_msg()) {
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::NullArgEx::NullArgEx(const vector_s &vect)
-    : base(vect, init_msg()) {
+scan::NullArgEx::NullArgEx(const vector_s &t_vect)
+    : base(t_vect, init_msg()) {
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::NullArgEx::NullArgEx(const vector_s &vect, const string &msg)
-    : base(vect, msg) {
+scan::NullArgEx::NullArgEx(const vector_s &t_vect, const string &t_msg)
+    : base(t_vect, t_msg) {
 }
 
 /// ***
 /// Print exception information to standard error
 /// ***
-void Scan::NullArgEx::show() const
+void scan::NullArgEx::show() const
 {
     Util::except(*this);
 }
@@ -38,7 +38,7 @@ void Scan::NullArgEx::show() const
 /// ***
 /// Get the name of the exception
 /// ***
-const std::string Scan::NullArgEx::name() const noexcept
+const std::string scan::NullArgEx::name() const noexcept
 {
     return NAME;
 }
@@ -46,7 +46,7 @@ const std::string Scan::NullArgEx::name() const noexcept
 /// ***
 /// Get exception information to pass to base class
 /// ***
-const std::string Scan::NullArgEx::init_msg() const noexcept
+const std::string scan::NullArgEx::init_msg() const noexcept
 {
     return "Null argument exception was thrown";
 }

--- a/SvcScan/src/nullptrex.cpp
+++ b/SvcScan/src/nullptrex.cpp
@@ -9,21 +9,21 @@
 /// ***
 /// Initialize the object
 /// ***
-Scan::NullPtrEx::NullPtrEx(const char *argp)
-    : base({ argp }, init_msg()) {
+scan::NullPtrEx::NullPtrEx(const char *t_argp)
+    : base({ t_argp }, init_msg()) {
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::NullPtrEx::NullPtrEx(const vector_s &vect)
-    : base(vect, init_msg()) {
+scan::NullPtrEx::NullPtrEx(const vector_s &t_vect)
+    : base(t_vect, init_msg()) {
 }
 
 /// ***
 /// Print exception information to standard error
 /// ***
-void Scan::NullPtrEx::show() const
+void scan::NullPtrEx::show() const
 {
     Util::except(*this);
 }
@@ -31,7 +31,7 @@ void Scan::NullPtrEx::show() const
 /// ***
 /// Get the name of the exception
 /// ***
-const std::string Scan::NullPtrEx::name() const noexcept
+const std::string scan::NullPtrEx::name() const noexcept
 {
     return NAME;
 }
@@ -39,7 +39,7 @@ const std::string Scan::NullPtrEx::name() const noexcept
 /// ***
 /// Get the name of the exception
 /// ***
-const std::string Scan::NullPtrEx::init_msg() const noexcept
+const std::string scan::NullPtrEx::init_msg() const noexcept
 {
     return "Null pointer exception was thrown";
 }

--- a/SvcScan/src/parser.cpp
+++ b/SvcScan/src/parser.cpp
@@ -12,46 +12,46 @@
 /// ***
 /// Command-line argument enumeration type
 /// ***
-enum class Scan::Parser::ArgType : short
+enum class scan::Parser::ArgType : short
 {
     flag,  // -f, --flag
     value  // --flag value
 };
 
-Scan::AutoProp<bool> Scan::Parser::verbose{ false };
+scan::AutoProp<bool> scan::Parser::verbose{ false };
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::Parser::Parser(const int &argc, const char *argv[])
+scan::Parser::Parser(const int &t_argc, const char *t_argv[])
 {
-    this->m_usage = string("Usage: ") + EXE + " [OPTIONS] TARGET";
+    m_usage = string("Usage: ") + EXE + " [OPTIONS] TARGET";
 
-    this->addr = &m_addr;
-    this->ports = &m_ports;
-    this->help_shown = false;
-    this->valid = false;
+    addr = &m_addr;
+    ports = &m_ports;
+    help_shown = false;
+    valid = false;
 
-    this->parse(argc, argv);
+    parse(t_argc, t_argv);
 }
 
 /// ***
 /// Display application usage information
 /// ***
-void Scan::Parser::help()
+void scan::Parser::help()
 {
     help_shown = true;
     std::stringstream ss;  // Usage info
 
-    ss << "SvcScan (https://github.com/vandavey/SvcScan)" << LF
-        << m_usage << LF << LF
-        << "TCP socket application banner grabber" << LF << LF
-        << "Positional Arguments:" << LF
-        << "  TARGET            Target address or domain name" << LF << LF
-        << "Optional Arguments:" << LF
+    ss << "SvcScan (https://github.com/vandavey/SvcScan)"              << LF
+        << m_usage                                               << LF << LF
+        << "TCP socket application banner grabber"               << LF << LF
+        << "Positional Arguments:"                                     << LF
+        << "  TARGET            Target address or domain name"   << LF << LF
+        << "Optional Arguments:"                                       << LF
         << "  -p/--port PORT    Port(s) - comma separated (no spaces)" << LF
-        << "  -h/--help         Show this help message and exit" << LF
-        << "  -v/--verbose      Enable verbose console output" << LF;
+        << "  -h/--help         Show this help message and exit"       << LF
+        << "  -v/--verbose      Enable verbose console output"         << LF;
 
     std::cout << ss.str() << LF;
 }
@@ -59,23 +59,23 @@ void Scan::Parser::help()
 /// ***
 /// Print usage and command-line argument error to stderr
 /// ***
-void Scan::Parser::error(const string &arg, const ArgType &arg_type) const
+void scan::Parser::error(const string &t_arg, const ArgType &t_arg_type) const
 {
-    switch (arg_type)
+    switch (t_arg_type)
     {
         case ArgType::flag:   // Flag value
         {
-            errorf("Missing flag argument: '%'", arg);
+            errorf("Missing flag argument: '%'", t_arg);
             break;
         }
         case ArgType::value:  // Argument value
         {
-            errorf("Missing required argument(s): '%'", arg);
+            errorf("Missing required argument(s): '%'", t_arg);
             break;
         }
         default:  // Invalid enum value
         {
-            throw ArgEx("arg_type", "Invalid enumeration value");
+            throw ArgEx("t_arg_type", "Invalid enumeration value");
         }
     }
 }
@@ -83,41 +83,41 @@ void Scan::Parser::error(const string &arg, const ArgType &arg_type) const
 /// ***
 /// Print usage and a formatted argument error to stderr
 /// ***
-void Scan::Parser::errorf(const string &msg, const string &arg) const
+void scan::Parser::errorf(const string &t_msg, const string &t_arg) const
 {
     std::cout << m_usage << LF;
-    Util::errorf(msg, arg);
+    Util::errorf(t_msg, t_arg);
     std::cout << LF;
 }
 
 /// ***
 /// Parse and validate command-line arguments
 /// ***
-void Scan::Parser::parse(const uint &argc, const char *argv[])
+void scan::Parser::parse(const uint &t_argc, const char *t_argv[])
 {
-    if (argc == NULL)
+    if (t_argc == NULL)
     {
-        throw NullArgEx("argc");
+        throw NullArgEx("t_argc");
     }
 
-    if (argv == nullptr)
+    if (t_argv == nullptr)
     {
-        throw NullPtrEx("argv");
+        throw NullPtrEx("t_argv");
     }
 
     // Show usage information
-    if (argc == 1)
+    if (t_argc == 1)
     {
         help();
         return;
     }
 
     // Parse arguments (exclude program path)
-    for (uint i{ 1 }; i < argc; i++)
+    for (uint i{ 1 }; i < t_argc; i++)
     {
-        if (argv[i] != nullptr)
+        if (t_argv[i] != nullptr)
         {
-            m_argv.add(argv[i]);
+            m_argv.add(t_argv[i]);
         }
     }
 
@@ -132,9 +132,9 @@ void Scan::Parser::parse(const uint &argc, const char *argv[])
 /// ***
 /// Validate arguments parsed from cmd-line
 /// ***
-void Scan::Parser::validate(list_s &list)
+void scan::Parser::validate(list_s &t_list)
 {
-    valid = parse_aliases(list) && parse_flags(list);
+    valid = parse_aliases(t_list) && parse_flags(t_list);
 
     // Invalid arguments parsed
     if (!valid.get())
@@ -144,7 +144,7 @@ void Scan::Parser::validate(list_s &list)
     }
 
     // Validate remaining arguments
-    switch (list.size())
+    switch (t_list.size())
     {
         case 0:   // Missing TARGET
         {
@@ -161,24 +161,24 @@ void Scan::Parser::validate(list_s &list)
                 return;
             }
 
-            m_addr = list[0];
+            m_addr = t_list[0];
             break;
         }
         case 2:   // Format: [TARGET PORTS]
         {
-            if (!parse_ports(list[1]))
+            if (!parse_ports(t_list[1]))
             {
                 valid = false;
                 return;
             }
 
-            m_addr = list[0];
+            m_addr = t_list[0];
             break;
         }
         default:  // Unrecognized arguments
         {
             valid = false;
-            errorf("Failed to validate: '%'", list.join(", "));;
+            errorf("Failed to validate: '%'", t_list.join(", "));;
             return;
         }
     }
@@ -195,13 +195,13 @@ void Scan::Parser::validate(list_s &list)
 /// ***
 /// Parse and validate cmd-line flag aliases and values
 /// ***
-const bool Scan::Parser::parse_aliases(list_s &list)
+const bool scan::Parser::parse_aliases(list_s &t_list)
 {
-    if (list.empty())
+    if (t_list.empty())
     {
         return true;
     }
-    const vector_s clone{ list };
+    const vector_s clone{ t_list };
 
     // Validate arg aliases and values
     for (const string &elem : clone)
@@ -211,7 +211,6 @@ const bool Scan::Parser::parse_aliases(list_s &list)
         {
             continue;
         }
-        bool skip{ false };
 
         // Validate cmd-line arg aliases (-<alias>)
         for (const char &ch : elem)
@@ -235,15 +234,15 @@ const bool Scan::Parser::parse_aliases(list_s &list)
                 case 'p':  // Validate ports
                 {
                     // Arg value index out of range
-                    if (elem == list.last())
+                    if (elem == t_list.last())
                     {
                         error("-p PORT", ArgType::flag);
                         return false;
                     }
-                    size_t index{ static_cast<size_t>(list.index_of(elem)) };
+                    size_t idx{ static_cast<size_t>(t_list.index_of(elem)) };
 
                     // Parse/validate port substrings
-                    if (!parse_ports(list[index + 1]))
+                    if (!parse_ports(t_list[idx + 1]))
                     {
                         return false;
                     }
@@ -256,7 +255,7 @@ const bool Scan::Parser::parse_aliases(list_s &list)
                 }
             }
         }
-        list.remove(elem);
+        t_list.remove(elem);
     }
     return true;
 }
@@ -264,13 +263,13 @@ const bool Scan::Parser::parse_aliases(list_s &list)
 /// ***
 /// Parse and validate cmd-line flags and values
 /// ***
-const bool Scan::Parser::parse_flags(list_s &list)
+const bool scan::Parser::parse_flags(list_s &t_list)
 {
-    if (list.empty())
+    if (t_list.empty())
     {
         return true;
     }
-    const vector_s clone{ list };
+    const vector_s clone{ t_list };
 
     // Validate arg flags and values
     for (const string &elem : clone)
@@ -292,7 +291,7 @@ const bool Scan::Parser::parse_flags(list_s &list)
         if (elem == "--verbose")
         {
             verbose = true;
-            list.remove(elem);
+            t_list.remove(elem);
             continue;
         }
 
@@ -300,18 +299,18 @@ const bool Scan::Parser::parse_flags(list_s &list)
         if (elem == "--port")
         {
             // Argument value index out of range
-            if (elem == list.last())
+            if (elem == t_list.last())
             {
                 error("--port PORT", ArgType::flag);
                 return false;
             }
 
             // Parse/validate port substrings
-            if (!parse_ports(list[list.index_of(elem) + 1]))
+            if (!parse_ports(t_list[t_list.index_of(elem) + 1]))
             {
                 return false;
             }
-            list.remove(elem);
+            t_list.remove(elem);
             return true;
         }
 
@@ -325,15 +324,15 @@ const bool Scan::Parser::parse_flags(list_s &list)
 /// ***
 /// Extract port number substrings from comma delimited string
 /// ***
-const bool Scan::Parser::parse_ports(const string &ports)
+const bool scan::Parser::parse_ports(const string &t_ports)
 {
-    if (ports.empty())
+    if (t_ports.empty())
     {
         return false;
     }
 
     // Validate port numbers
-    for (const string &port : Util::split(ports, ","))
+    for (const string &port : Util::split(t_ports, ","))
     {
         // Invalid port received
         if (!Socket::valid_port(port))
@@ -344,6 +343,6 @@ const bool Scan::Parser::parse_ports(const string &ports)
         m_ports.add(port);
     }
 
-    m_argv.remove(ports);
+    m_argv.remove(t_ports);
     return true;
 }

--- a/SvcScan/src/record.cpp
+++ b/SvcScan/src/record.cpp
@@ -8,40 +8,40 @@
 /// ***
 /// Initialize the object
 /// ***
-Scan::Record::Record(const Record &row)
+scan::Record::Record(const Record &t_row)
 {
-    this->port = row.port;
-    this->state = row.state;
-    this->service = row.service;
-    this->version = row.version;
+    port = t_row.port;
+    state = t_row.state;
+    service = t_row.service;
+    version = t_row.version;
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::Record::Record(const array_s &fields)
+scan::Record::Record(const array_s &t_fields)
 {
-    this->port = fields[0];
-    this->state = fields[1];
-    this->service = fields[2];
-    this->version = fields[3];
+    port = t_fields[0];
+    state = t_fields[1];
+    service = t_fields[2];
+    version = t_fields[3];
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::Record::Record(const SvcInfo &si)
+scan::Record::Record(const SvcInfo &t_si)
 {
-    this->port = si.port.get() + "/tcp";
-    this->state = state_str(si.state.get());
-    this->service = si.service.get();
-    this->version = si.version.get();
+    port = t_si.port.get() + "/tcp";
+    state = state_str(t_si.state.get());
+    service = t_si.service.get();
+    version = t_si.version.get();
 }
 
 /// ***
 /// Cast operator overload
 /// ***
-Scan::Record::operator const array_s() const
+scan::Record::operator const array_s() const
 {
     return { port.get(), state.get(), service.get(), version.get() };
 }
@@ -49,7 +49,7 @@ Scan::Record::operator const array_s() const
 /// ***
 /// Cast operator overload
 /// ***
-Scan::Record::operator const std::string() const
+scan::Record::operator const std::string() const
 {
     return list_s::join(operator const vector_s(), "  ");
 }
@@ -57,7 +57,7 @@ Scan::Record::operator const std::string() const
 /// ***
 /// Cast operator overload
 /// ***
-Scan::Record::operator const vector_s() const
+scan::Record::operator const vector_s() const
 {
     return { port.get(), state.get(), service.get(), version.get() };
 }
@@ -65,33 +65,33 @@ Scan::Record::operator const vector_s() const
 /// ***
 /// Equality operator overload
 /// ***
-const bool Scan::Record::operator==(const Record &row) const
+const bool scan::Record::operator==(const Record &t_row) const
 {
-    return operator const array_s() == static_cast<array_s>(row);
+    return operator const array_s() == static_cast<array_s>(t_row);
 }
 
 /// ***
 /// Inequality operator overload
 /// ***
-const bool Scan::Record::operator!=(const Record &row) const
+const bool scan::Record::operator!=(const Record &t_row) const
 {
-    return operator const array_s() != static_cast<array_s>(row);
+    return operator const array_s() != static_cast<array_s>(t_row);
 }
 
 /// ***
 /// Determine if the left-hand record's port number is less
 /// ***
-const bool Scan::Record::is_less(const Record &lhs, const Record &rhs)
+const bool scan::Record::is_less(const Record &t_lhs, const Record &t_rhs)
 {
-    return stoi(lhs.port.get()) < stoi(rhs.port.get());
+    return stoi(t_lhs.port.get()) < stoi(t_rhs.port.get());
 }
 
 /// ***
 /// Retrieve the value associated with the given field
 /// ***
-const std::string Scan::Record::get_field(const SvcField &sf) const
+const std::string scan::Record::get_field(const SvcField &t_sf) const
 {
-    switch (sf)
+    switch (t_sf)
     {
         case SvcField::port:
             return port.get();
@@ -102,28 +102,28 @@ const std::string Scan::Record::get_field(const SvcField &sf) const
         case SvcField::version:
             return version.get();
         default:
-            return "";
+            return string();
     }
 }
 
 /// ***
 /// Set the value associated with the given field
 /// ***
-void Scan::Record::set_field(const SvcField &sf, const string &value)
+void scan::Record::set_field(const SvcField &t_sf, const string &t_value)
 {
-    switch (sf)
+    switch (t_sf)
     {
         case SvcField::port:
-            port = value;
+            port = t_value;
             break;
         case SvcField::service:
-            service = value;
+            service = t_value;
             break;
         case SvcField::state:
-            state = value;
+            state = t_value;
             break;
         case SvcField::version:
-            version = value;
+            version = t_value;
             break;
         default:
             break;
@@ -133,19 +133,19 @@ void Scan::Record::set_field(const SvcField &sf, const string &value)
 /// ***
 /// Add padding to all fields in vector and return as copy
 /// ***
-const Scan::Record Scan::Record::pad_fields(const map_sf<size_t> &dict) const
+const scan::Record scan::Record::pad_fields(const map_sf<size_t> &t_dict) const
 {
-    Record clone(*this);
+    Record clone{ *this };
 
     // Add padding to fields
-    for (const map_sf<size_t>::value_type &pair : dict)
+    for (const map_sf<size_t>::value_type &pair : t_dict)
     {
         const size_t field_width{ get_field(pair.first).size() };
 
         // Invalid maximum width
         if (pair.second < field_width)
         {
-            throw ArgEx("width_map", "Invalid key value (size_t)");
+            throw ArgEx("t_dict", "Invalid key value (size_t)");
         }
         const size_t delta{ pair.second - field_width };
 
@@ -162,9 +162,9 @@ const Scan::Record Scan::Record::pad_fields(const map_sf<size_t> &dict) const
 /// ***
 /// Get the string equivalent of the given host state
 /// ***
-const std::string Scan::Record::state_str(const HostState &hs) const noexcept
+const std::string scan::Record::state_str(const HostState &t_hs) const noexcept
 {
-    switch (hs)
+    switch (t_hs)
     {
         case HostState::open:    // Open state
         {

--- a/SvcScan/src/socket.cpp
+++ b/SvcScan/src/socket.cpp
@@ -15,42 +15,42 @@
 /// ***
 /// Initialize the object
 /// ***
-Scan::Socket::Socket()
+scan::Socket::Socket()
 {
-    this->addr = &m_addr;
-    this->ports = &m_ports;
+    addr = &m_addr;
+    ports = &m_ports;
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::Socket::Socket(const Socket &sock)
+scan::Socket::Socket(const Socket &t_sock)
 {
-    this->m_addr = sock.m_addr;
-    this->m_ports = sock.m_ports;
-    this->m_services = sock.m_services;
-    this->m_sock = sock.m_sock;
+    m_addr = t_sock.m_addr;
+    m_ports = t_sock.m_ports;
+    m_services = t_sock.m_services;
+    m_sock = t_sock.m_sock;
 
-    this->addr = &m_addr;
-    this->ports = &m_ports;
+    addr = &m_addr;
+    ports = &m_ports;
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::Socket::Socket(const property_s &addr, const property_l &ports)
+scan::Socket::Socket(const property_s &t_addr, const property_l &t_ports)
 {
-    this->m_addr = addr.get();
-    this->m_ports = ports.get();
+    m_addr = t_addr.get();
+    m_ports = t_ports.get();
 
-    this->addr = &m_addr;
-    this->ports = &m_ports;
+    addr = &m_addr;
+    ports = &m_ports;
 }
 
 /// ***
 /// Destroy the object
 /// ***
-Scan::Socket::~Socket()
+scan::Socket::~Socket()
 {
     WSACleanup();
 }
@@ -58,12 +58,12 @@ Scan::Socket::~Socket()
 /// ***
 /// Assignment operator overload
 /// ***
-Scan::Socket &Scan::Socket::operator=(const Socket &sock) noexcept
+scan::Socket &scan::Socket::operator=(const Socket &t_sock) noexcept
 {
-    m_addr = sock.m_addr;
-    m_ports = sock.m_ports;
-    m_services = sock.m_services;
-    m_sock = sock.m_sock;
+    m_addr = t_sock.m_addr;
+    m_ports = t_sock.m_ports;
+    m_services = t_sock.m_services;
+    m_sock = t_sock.m_sock;
 
     addr = &m_addr;
     ports = &m_ports;
@@ -74,9 +74,9 @@ Scan::Socket &Scan::Socket::operator=(const Socket &sock) noexcept
 /// ***
 /// Determine if port string is a valid network port
 /// ***
-const bool Scan::Socket::valid_port(const string &port)
+const bool scan::Socket::valid_port(const string &t_port)
 {
-    for (const uchar &ch : port)
+    for (const uchar &ch : t_port)
     {
         // Can't parse as integer
         if (!std::isdigit(ch))
@@ -84,16 +84,16 @@ const bool Scan::Socket::valid_port(const string &port)
             return false;
         }
     }
-    const int iport{ stoi(port) };
+    const int iport{ stoi(t_port) };
     return (iport >= 0) && (iport <= 65535);
 }
 
 /// ***
 /// Determine if vector strings are valid network ports
 /// ***
-const bool Scan::Socket::valid_port(const vector_s &ports)
+const bool scan::Socket::valid_port(const vector_s &t_ports)
 {
-    for (const string &port : ports)
+    for (const string &port : t_ports)
     {
         if (!valid_port(port))
         {
@@ -106,24 +106,24 @@ const bool Scan::Socket::valid_port(const vector_s &ports)
 /// ***
 /// Determine if IPv4 (dot-decimal notation) is valid
 /// ***
-const int Scan::Socket::valid_ip(const string &addr)
+const int scan::Socket::valid_ip(const string &t_addr)
 {
     // Don't attempt resolution (invalid/unknown format)
-    if (Util::count(addr, '.') != 3)
+    if (Util::count(t_addr, '.') != 3)
     {
         return SOCKET_ERROR;
     }
     int iaddr{ static_cast<int>(sizeof(in_addr)) };
 
     // Convert IPv4 string to binary
-    const int code{ inet_pton(AF_INET, addr.c_str(), &iaddr) };
+    const int code{ inet_pton(AF_INET, t_addr.c_str(), &iaddr) };
     return (code == 1) ? 0 : 1;
 }
 
 /// ***
 /// Connect to the remote host
 /// ***
-void Scan::Socket::connect()
+void scan::Socket::connect()
 {
     int wsa_rc;
     WSAData wsadata;
@@ -139,7 +139,7 @@ void Scan::Socket::connect()
     // Invalid network ports
     if (!valid_port(m_ports))
     {
-        throw ArgEx("port", "Invalid port number");
+        throw ArgEx("m_ports", "Invalid port number");
     }
 
     // Print scan start message
@@ -204,7 +204,7 @@ void Scan::Socket::connect()
 /// ***
 /// Close underlying socket and set its handle to default
 /// ***
-void Scan::Socket::close(addrinfoW *ai_ptr)
+void scan::Socket::close(addrinfoW *t_aiptr)
 {
     if (!valid_sock(m_sock))
     {
@@ -212,9 +212,9 @@ void Scan::Socket::close(addrinfoW *ai_ptr)
     }
 
     // Free dynamic resources
-    if (ai_ptr != nullptr)
+    if (t_aiptr != nullptr)
     {
-        FreeAddrInfoW(ai_ptr);
+        FreeAddrInfoW(t_aiptr);
     }
 
     // Attempt to close socket descriptor
@@ -228,7 +228,7 @@ void Scan::Socket::close(addrinfoW *ai_ptr)
 /// ***
 /// Print WSA error information to standard error
 /// ***
-void Scan::Socket::error() const
+void scan::Socket::error() const
 {
     const int err{ get_error() };
     error((!err ? -1 : err), string());
@@ -237,36 +237,36 @@ void Scan::Socket::error() const
 /// ***
 /// Print WSA error information to standard error
 /// ***
-void Scan::Socket::error(const int &err) const
+void scan::Socket::error(const int &t_err) const
 {
-    if (err == NULL)
+    if (t_err == NULL)
     {
-        throw NullArgEx("err");
+        throw NullArgEx("t_err");
     }
-    error(err, string());
+    error(t_err, string());
 }
 
 /// ***
 /// Format and print a WSA error message to standard error
 /// ***
-void Scan::Socket::error(const string &arg) const
+void scan::Socket::error(const string &t_arg) const
 {
     const int err{ get_error() };
-    error((!err ? -1 : err), arg);
+    error((!err ? -1 : err), t_arg);
 }
 
 /// ***
 /// Format and print a WSA error message to standard error
 /// ***
-void Scan::Socket::error(const int &err, const string &arg) const
+void scan::Socket::error(const int &t_err, const string &t_arg) const
 {
-    if (err == NULL)
+    if (t_err == NULL)
     {
-        throw NullArgEx("err");
+        throw NullArgEx("t_err");
     }
-    const string dest{ arg.empty() ? "destination host" : arg };
+    const string dest{ t_arg.empty() ? "destination host" : t_arg };
 
-    switch (err)
+    switch (t_err)
     {
         case WSAETIMEDOUT:       // Recv/send timeout
         case WSAEWOULDBLOCK:     // Connect timeout
@@ -301,7 +301,7 @@ void Scan::Socket::error(const int &err, const string &arg) const
         }
         default:                 // Default (error code)
         {
-            Util::errorf("Winsock error: %", Util::itos(err));
+            Util::errorf("Winsock error: %", Util::itos(t_err));
             break;
         }
     }
@@ -310,37 +310,37 @@ void Scan::Socket::error(const int &err, const string &arg) const
 /// ***
 /// Determine if socket is valid
 /// ***
-const bool Scan::Socket::valid_sock(const SOCKET &sock) const noexcept
+const bool scan::Socket::valid_sock(const SOCKET &t_sock) const noexcept
 {
-    if (sock == NULL)
+    if (t_sock == NULL)
     {
         return false;
     }
-    return (sock != INVALID_SOCKET) && (sock != SOCKET_ERROR);
+    return (t_sock != INVALID_SOCKET) && (t_sock != SOCKET_ERROR);
 }
 
 /// ***
 /// Connect to the remote host and read banner data
 /// ***
-const Scan::HostState Scan::Socket::connect(addrinfoW *ai_ptr,
-                                            char (&buffer)[BUFFER_SIZE],
-                                            const EndPoint &ep) {
+const scan::HostState scan::Socket::connect(addrinfoW *t_aiptr,
+                                            char (&t_buffer)[BUFFER_SIZE],
+                                            const EndPoint &t_ep) {
     if (!valid_sock(m_sock))
     {
         throw ArgEx("m_sock", "Invalid socket descriptor");
     }
 
-    if (ai_ptr == nullptr)
+    if (t_aiptr == nullptr)
     {
-        throw NullPtrEx("ai_ptr");
+        throw NullPtrEx("t_aiptr");
     }
     fd_set fds{ 1, { m_sock } };
 
     int ec;
-    const int addr_len{ static_cast<int>(ai_ptr->ai_addrlen) };
+    const int addr_len{ static_cast<int>(t_aiptr->ai_addrlen) };
 
     // Connect to the remote host
-    int rc{ ::connect(m_sock, ai_ptr->ai_addr, addr_len) };
+    int rc{ ::connect(m_sock, t_aiptr->ai_addr, addr_len) };
 
     if (rc == SOCKET_ERROR)
     {
@@ -349,7 +349,7 @@ const Scan::HostState Scan::Socket::connect(addrinfoW *ai_ptr,
         {
             if (Parser::verbose.get())
             {
-                error(ec, ep);
+                error(ec, t_ep);
             }
             return HostState::closed;
         }
@@ -359,7 +359,7 @@ const Scan::HostState Scan::Socket::connect(addrinfoW *ai_ptr,
         {
             if (Parser::verbose.get())
             {
-                error(ep);
+                error(t_ep);
             }
             return (rc == -1) ? HostState::closed : HostState::unknown;
         }
@@ -369,7 +369,7 @@ const Scan::HostState Scan::Socket::connect(addrinfoW *ai_ptr,
     // Print connection message
     if (Parser::verbose.get())
     {
-        Util::print(Util::fmt("Connection established to %", ep));
+        Util::print(Util::fmt("Connection established to %", t_ep));
     }
 
     // Connected - check stream readability
@@ -386,7 +386,7 @@ const Scan::HostState Scan::Socket::connect(addrinfoW *ai_ptr,
         }
         case 1:   // Banner available
         {
-            if (::recv(m_sock, buffer, BUFFER_SIZE, 0) == SOCKET_ERROR)
+            if (::recv(m_sock, t_buffer, BUFFER_SIZE, 0) == SOCKET_ERROR)
             {
                 error();
             }
@@ -410,7 +410,7 @@ const Scan::HostState Scan::Socket::connect(addrinfoW *ai_ptr,
 /// ***
 /// Get the last error using WSAGetLastError
 /// ***
-const int Scan::Socket::get_error() const
+const int scan::Socket::get_error() const
 {
     return WSAGetLastError();
 }
@@ -418,15 +418,15 @@ const int Scan::Socket::get_error() const
 /// ***
 /// Poll underlying socket for reading and writing
 /// ***
-const int Scan::Socket::select(fd_set *rfds_ptr, fd_set *wfds_ptr,
-                                                 const timeval &to) const {
-    if (!rfds_ptr && !wfds_ptr)
+const int scan::Socket::select(fd_set *t_rfds_ptr, fd_set *t_wfds_ptr,
+                                                   const timeval &t_to) const {
+    if (!t_rfds_ptr && !t_wfds_ptr)
     {
-        throw NullPtrEx({ "rfds_ptr", "wfds_ptr" });
+        throw NullPtrEx({ "t_rfds_ptr", "t_wfds_ptr" });
     }
 
     // Determine if socket is readable/writable 
-    int rc{ ::select(0, rfds_ptr, wfds_ptr, nullptr, &to) };
+    int rc{ ::select(0, t_rfds_ptr, t_wfds_ptr, nullptr, &t_to) };
 
     // Return socket polling result
     if (rc != NO_ERROR)
@@ -469,13 +469,13 @@ const int Scan::Socket::select(fd_set *rfds_ptr, fd_set *wfds_ptr,
 /// ***
 /// Configure blocking options on underlying socket
 /// ***
-const int Scan::Socket::set_blocking(const bool &do_block)
+const int scan::Socket::set_blocking(const bool &t_do_block)
 {
     if (!valid_sock(m_sock))
     {
         throw ArgEx("m_sock", "Invalid socket descriptor");
     }
-    ulong mode{ static_cast<ulong>(do_block ? 0 : 1) };
+    ulong mode{ static_cast<ulong>(t_do_block ? 0 : 1) };
 
     // Modify socket blocking
     return ::ioctlsocket(m_sock, FIONBIO, &mode);
@@ -484,16 +484,16 @@ const int Scan::Socket::set_blocking(const bool &do_block)
 /// ***
 /// Prepare socket for connection to destination host
 /// ***
-addrinfoW *Scan::Socket::startup(SvcInfo &si, const string &port)
+addrinfoW *scan::Socket::startup(SvcInfo &t_si, const string &t_port)
 {
     if (m_sock == NULL)
     {
         throw NullArgEx("m_sock");
     }
 
-    if (!valid_port(port))
+    if (!valid_port(t_port))
     {
-        throw ArgEx("port", "Invalid port number");
+        throw ArgEx("t_port", "Invalid port number");
     }
     int rc;
 
@@ -505,18 +505,18 @@ addrinfoW *Scan::Socket::startup(SvcInfo &si, const string &port)
 
     // Resolve address information
     rc = GetAddrInfoW(Util::utf16(m_addr).c_str(),
-                      Util::utf16(port).c_str(),
+                      Util::utf16(t_port).c_str(),
                       static_cast<addrinfoW *>(&ai_hints),
                       static_cast<addrinfoW **>(&ptr));
 
     // Handle DNS lookup errors
     if (rc != 0)
     {
-        error(EndPoint(m_addr, port));
+        error(EndPoint(m_addr, t_port));
         FreeAddrInfoW(ptr);
         m_sock = INVALID_SOCKET;
 
-        m_services.add(update_svc(si, port, HostState::unknown));
+        m_services.add(update_svc(t_si, t_port, HostState::unknown));
         return nullptr;
     }
     m_sock = socket(ptr->ai_family, ptr->ai_socktype, ptr->ai_protocol);
@@ -528,7 +528,7 @@ addrinfoW *Scan::Socket::startup(SvcInfo &si, const string &port)
         FreeAddrInfoW(ptr);
         m_sock = INVALID_SOCKET;
 
-        m_services.add(update_svc(si, port, HostState::unknown));
+        m_services.add(update_svc(t_si, t_port, HostState::unknown));
         ptr = nullptr;
     }
     return ptr;
@@ -537,18 +537,18 @@ addrinfoW *Scan::Socket::startup(SvcInfo &si, const string &port)
 /// ***
 /// Modify service information for the given service reference
 /// ***
-Scan::SvcInfo &Scan::Socket::update_svc(SvcInfo &si,
-                                        const string &port,
-                                        const HostState &hs) const {
+scan::SvcInfo &scan::Socket::update_svc(SvcInfo &t_si,
+                                        const string &t_port,
+                                        const HostState &t_hs) const {
     // Invalid port number
-    if (!valid_port(port))
+    if (!valid_port(t_port))
     {
-        throw ArgEx("port", "Invalid port number");
+        throw ArgEx("t_port", "Invalid port number");
     }
 
-    if (!si.banner.get().empty())
+    if (!t_si.banner.get().empty())
     {
-        return si;
+        return t_si;
     }
     const char addr[]{ "0.0.0.0" };
 
@@ -559,13 +559,13 @@ Scan::SvcInfo &Scan::Socket::update_svc(SvcInfo &si,
     if (inet_pton(AF_INET, &addr[0], &iaddr) != 1)
     {
         error();
-        return si;
+        return t_si;
     }
 
     // Initialize sockaddr_in structure
     sockaddr_in sa{ AF_INET };
     sa.sin_addr.s_addr = iaddr;
-    sa.sin_port = htons(static_cast<ushort>(stoi(port)));
+    sa.sin_port = htons(static_cast<ushort>(stoi(t_port)));
 
     // Reinterpret sockaddr_in memory address as sockaddr pointer
     const sockaddr *sa_ptr{ reinterpret_cast<sockaddr *>(&sa) };
@@ -577,8 +577,8 @@ Scan::SvcInfo &Scan::Socket::update_svc(SvcInfo &si,
     code = getnameinfo(sa_ptr, sizeof(sa), host_buffer, NI_MAXHOST, svc_buffer,
                                                                     NI_MAXSERV,
                                                                     NULL);
-    si.state = hs;
-    si.service = code ? "" : svc_buffer;
+    t_si.state = t_hs;
+    t_si.service = code ? "" : svc_buffer;
 
-    return si;
+    return t_si;
 }

--- a/SvcScan/src/svcinfo.cpp
+++ b/SvcScan/src/svcinfo.cpp
@@ -10,57 +10,58 @@
 /// ***
 /// Initialize the object
 /// ***
-Scan::SvcInfo::SvcInfo(const SvcInfo &si)
+scan::SvcInfo::SvcInfo(const SvcInfo &t_si)
 {
-    this->swap(si);
+    swap(t_si);
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::SvcInfo::SvcInfo(const EndPoint &ep, const HostState &hs)
+scan::SvcInfo::SvcInfo(const EndPoint &t_ep, const HostState &t_hs)
 {
-    this->addr = ep.addr.get();
-    this->port = ep.port.get();
-    this->state = hs;
+    addr = t_ep.addr.get();
+    port = t_ep.port.get();
+    state = t_hs;
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::SvcInfo::SvcInfo(const EndPoint &ep, const string &banner,
-                                           const HostState &hs) {
-    this->addr = ep.addr.get();
-    this->port = ep.port.get();
-    this->state = hs;
-    this->parse(banner);
+scan::SvcInfo::SvcInfo(const EndPoint &t_ep, const string &t_banner,
+                                             const HostState &t_hs) {
+    addr = t_ep.addr.get();
+    port = t_ep.port.get();
+    state = t_hs;
+
+    parse(t_banner);
 }
 
 /// ***
 /// Assignment operator overload
 /// ***
-Scan::SvcInfo &Scan::SvcInfo::operator=(const SvcInfo &si) noexcept
+scan::SvcInfo &scan::SvcInfo::operator=(const SvcInfo &t_si) noexcept
 {
-    return swap(si);
+    return swap(t_si);
 }
 
 /// ***
 /// Parse a TCP network application banner
 /// ***
-void Scan::SvcInfo::parse(const string &banner_txt)
+void scan::SvcInfo::parse(const string &t_banner)
 {
-    if (banner_txt.empty())
+    if (t_banner.empty())
     {
         return;
     }
 
     // Unable to detect extended service info
-    if (Util::count(banner_txt, '-') < 2)
+    if (Util::count(t_banner, '-') < 2)
     {
-        banner = Util::indent(banner_txt, 11, true);
+        banner = Util::indent(11, t_banner, true);
         return;
     }
-    banner = upto_eol(banner_txt);
+    banner = upto_eol(t_banner);
 
     const vector_s vect{ Util::split(banner.get(), "-", 2) };
 
@@ -97,40 +98,40 @@ void Scan::SvcInfo::parse(const string &banner_txt)
 /// ***
 /// Read string data until EOL sequence is detected
 /// ***
-const std::string Scan::SvcInfo::upto_eol(const string &data) const
+const std::string scan::SvcInfo::upto_eol(const string &t_data) const
 {
-    if (data.empty())
+    if (t_data.empty())
     {
-        return data;
+        return t_data;
     }
-    size_t index;
+    size_t idx;
 
     // Up to NT EOL
-    if ((index = data.find(Util::CRLF)) != -1)
+    if ((idx = t_data.find(Util::CRLF)) != -1)
     {
-        return data.substr(0, index);
+        return t_data.substr(0, idx);
     }
 
     // Up to POSIX EOL
-    if ((index = data.find(Util::LF)) != -1)
+    if ((idx = t_data.find(Util::LF)) != -1)
     {
-        return data.substr(0, index);
+        return t_data.substr(0, idx);
     }
-    return data;
+    return t_data;
 }
 
 /// ***
 /// Swap mutable member values with reference's values
 /// ***
-Scan::SvcInfo &Scan::SvcInfo::swap(const SvcInfo &si) noexcept
+scan::SvcInfo &scan::SvcInfo::swap(const SvcInfo &t_si) noexcept
 {
-    addr = si.addr;
-    banner = si.banner;
-    port = si.port;
-    proto = si.proto;
-    service = si.service;
-    state = si.state;
-    version = si.version;
+    addr = t_si.addr;
+    banner = t_si.banner;
+    port = t_si.port;
+    proto = t_si.proto;
+    service = t_si.service;
+    state = t_si.state;
+    version = t_si.version;
 
     return *this;
 }

--- a/SvcScan/src/svcscan.cpp
+++ b/SvcScan/src/svcscan.cpp
@@ -17,7 +17,7 @@
 /// ***
 int main(const int argc, const char *argv[])
 {
-    using namespace Scan;
+    using namespace scan;
 
     // Enable virtual terminal sequences
     if (Util::enable_vt() != 0)

--- a/SvcScan/src/svctable.cpp
+++ b/SvcScan/src/svctable.cpp
@@ -9,24 +9,24 @@
 /// ***
 /// Initialize the object
 /// ***
-Scan::SvcTable::SvcTable(const SvcTable &st) : SvcTable()
+scan::SvcTable::SvcTable(const SvcTable &t_st) : SvcTable()
 {
-    this->m_list = st.m_list;
+    m_list = t_st.m_list;
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::SvcTable::SvcTable(const string &addr, const vector_si &vect) : SvcTable()
-{
-    this->m_addr = addr;
-    this->add(vect);
+scan::SvcTable::SvcTable(const string &t_addr,
+                         const vector_si &t_vect) : SvcTable() {
+    m_addr = t_addr;
+    add(t_vect);
 }
 
 /// ***
 /// Initialize the object
 /// ***
-Scan::SvcTable::SvcTable()
+scan::SvcTable::SvcTable()
 {
     // Add header record
     if (m_list.empty())
@@ -38,29 +38,29 @@ Scan::SvcTable::SvcTable()
 /// ***
 /// Subscript operator overload
 /// ***
-const Scan::Record Scan::SvcTable::operator[](const size_t &index) const
+const scan::Record scan::SvcTable::operator[](const size_t &t_idx) const
 {
-    if (index >= m_list.size())
+    if (t_idx >= m_list.size())
     {
-        throw ArgEx("index", "Invalid list index (out of range)");
+        throw ArgEx("t_idx", "Invalid list idx (out of range)");
     }
-    return m_list.at(index);
+    return m_list.at(t_idx);
 }
 
 /// ***
 /// Add a new record to the underlying list
 /// ***
-void Scan::SvcTable::add(const SvcInfo &si)
+void scan::SvcTable::add(const SvcInfo &t_si)
 {
-    m_list.add(Record(si));
+    m_list.add(Record(t_si));
 }
 
 /// ***
 /// Add new records to the underlying list
 /// ***
-void Scan::SvcTable::add(const vector_si &vect)
+void scan::SvcTable::add(const vector_si &t_vect)
 {
-    for (const SvcInfo &si : vect)
+    for (const SvcInfo &si : t_vect)
     {
         add(si);
     }
@@ -69,7 +69,7 @@ void Scan::SvcTable::add(const vector_si &vect)
 /// ***
 /// Format the underlying list as a table string
 /// ***
-const std::string Scan::SvcTable::str() const
+const std::string scan::SvcTable::str() const
 {
     std::stringstream ss;
 
@@ -106,14 +106,14 @@ const std::string Scan::SvcTable::str() const
 /// ***
 /// Get the max character width of the given field
 /// ***
-const int Scan::SvcTable::field_width(const vector_r &vect, 
-                                      const SvcField &sf) const {
+const int scan::SvcTable::field_width(const vector_r &t_vect, 
+                                      const SvcField &t_sf) const {
     size_t max_width{ 0 };
 
     // Compare fields width to previous max
-    for (const Record &row : m_list)
+    for (const Record &row : t_vect)
     {
-        const size_t width{ row.get_field(sf).size() };
+        const size_t width{ row.get_field(t_sf).size() };
         max_width = (width > max_width) ? width : max_width;
     }
     return static_cast<int>(max_width);

--- a/SvcScan/src/util.cpp
+++ b/SvcScan/src/util.cpp
@@ -15,16 +15,16 @@
 /// ***
 /// Console foreground color enumeration type
 /// ***
-enum class Scan::Util::FgColor : short
+enum class scan::Util::FgColor : short
 {
     cyan,   // Cyan foreground
     red,    // Red foreground
     yellow  // Yellow foreground
 };
 
-Scan::AutoProp<bool> Scan::Util::vt_enabled(false);
+scan::AutoProp<bool> scan::Util::vt_enabled(false);
 
-Scan::Util::map_cs Scan::Util::m_icons
+scan::Util::map_cs scan::Util::m_icons
 {
     { FgColor::cyan,   "[*]" },
     { FgColor::yellow, "[!]" },
@@ -34,64 +34,64 @@ Scan::Util::map_cs Scan::Util::m_icons
 /// ***
 /// Write an error message to standard error
 /// ***
-void Scan::Util::error(const string &msg)
+void scan::Util::error(const string &t_msg)
 {
-    print(FgColor::red, msg);
+    print(FgColor::red, t_msg);
 }
 
 /// ***
 /// Write formatted error message to standard error
 /// ***
-void Scan::Util::errorf(const string &msg, const string &arg)
+void scan::Util::errorf(const string &t_msg, const string &t_arg)
 {
-    if (msg.find('%') == -1)
+    if (t_msg.find('%') == -1)
     {
-        throw ArgEx("msg", "Missing format character");
+        throw ArgEx("t_msg", "Missing format character");
     }
-    print(FgColor::red, fmt(msg, arg));
+    print(FgColor::red, fmt(t_msg, t_arg));
 }
 
 /// ***
 /// Write exception information to standard error
 /// ***
-void Scan::Util::except(const ArgEx &ex)
+void scan::Util::except(const ArgEx &t_ex)
 {
-    error(ex.msg.get());
-    std::cerr << ex << LF;
+    error(t_ex.msg.get());
+    std::cerr << t_ex << LF;
 }
 
 /// ***
 /// Write general information to standard output
 /// ***
-void Scan::Util::print(const string &msg)
+void scan::Util::print(const string &t_msg)
 {
-    print(FgColor::cyan, msg);
+    print(FgColor::cyan, t_msg);
 }
 
 /// ***
 /// Write general information to standard output
 /// ***
-void Scan::Util::printf(const string &msg, const string &arg)
+void scan::Util::printf(const string &t_msg, const string &t_arg)
 {
-    if (msg.find('%') == -1)
+    if (t_msg.find('%') == -1)
     {
-        throw ArgEx("msg", "Missing format character");
+        throw ArgEx("t_msg", "Missing format character");
     }
-    print(FgColor::cyan, fmt(msg, arg));
+    print(FgColor::cyan, fmt(t_msg, t_arg));
 }
 
 /// ***
 /// Write a warning message to standard error
 /// ***
-void Scan::Util::warn(const string &msg)
+void scan::Util::warn(const string &t_msg)
 {
-    print(FgColor::yellow, msg);
+    print(FgColor::yellow, t_msg);
 }
 
 /// ***
 /// Enable virtual terminal sequence processing
 /// ***
-const int Scan::Util::enable_vt()
+const int scan::Util::enable_vt()
 {
     if (vt_enabled.get())
     {
@@ -126,59 +126,60 @@ const int Scan::Util::enable_vt()
 /// ***
 /// Count the number of char occurrences in a string
 /// ***
-const size_t Scan::Util::count(const string &str, const char &ch)
+const size_t scan::Util::count(const string &t_str, const char &t_ch)
 {
-    if (ch == NULL)
+    if (t_ch == NULL)
     {
-        throw NullArgEx("ch");
+        throw NullArgEx("t_ch");
     }
-    return static_cast<size_t>(std::count(str.begin(), str.end(), ch));
+    return static_cast<size_t>(std::count(t_str.begin(), t_str.end(), t_ch));
 }
 
 /// ***
 /// Convert a long long into a char pointer
 /// ***
-const char *Scan::Util::itoc(const llong &num)
+const char *scan::Util::itoc(const llong &t_num)
 {
-    if (num == NULL)
+    if (t_num == NULL)
     {
-        throw NullArgEx({ std::to_string(num) });
+        throw NullArgEx({ std::to_string(t_num) });
     }
 
-    const string num_s{ itos(num) };
+    const string num_s{ itos(t_num) };
     return num_s.empty() ? nullptr : num_s.c_str();
 }
 
 /// ***
 /// Split a delimited string and return as a vector
 /// ***
-const Scan::Util::vector_s Scan::Util::split(const string &data,
-                                             const string &delim) {
-    return split(data, delim, data.size());
+const scan::Util::vector_s scan::Util::split(const string &t_data,
+                                             const string &t_delim) {
+    // Default max split to data size
+    return split(t_data, t_delim, t_data.size());
 }
 
 /// ***
 /// Split a delimited string until split limit is reached
 /// ***
-const Scan::Util::vector_s Scan::Util::split(const string &data,
-                                             const string &delim,
-                                             const size_t &max_split) {
-    if (max_split == NULL)
+const scan::Util::vector_s scan::Util::split(const string &t_data,
+                                             const string &t_delim,
+                                             const size_t &t_max_split) {
+    if (t_max_split == NULL)
     {
-        throw NullArgEx("max_split");
+        throw NullArgEx("t_max_split");
     }
     vector_s vect;
 
     // Return empty string vector
-    if (data.empty())
+    if (t_data.empty())
     {
         return vect;
     }
 
     // No delimiter to split on
-    if (delim.empty())
+    if (t_delim.empty())
     {
-        vect.push_back(data);
+        vect.push_back(t_data);
         return vect;
     }
 
@@ -188,18 +189,18 @@ const Scan::Util::vector_s Scan::Util::split(const string &data,
     size_t i;
 
     // Iterate until next separator not found
-    while ((i = data.find_first_not_of(delim, next)) != -1)
+    while ((i = t_data.find_first_not_of(t_delim, next)) != -1)
     {
         // Add remaining data as element
-        if (count == max_split)
+        if (count == t_max_split)
         {
-            vect.push_back(data.substr(i, (data.size() - 1)));
+            vect.push_back(t_data.substr(i, (t_data.size() - 1)));
             break;
         }
         count += 1;
 
-        next = data.find(delim, i);
-        vect.push_back(data.substr(i, (next - i)));
+        next = t_data.find(t_delim, i);
+        vect.push_back(t_data.substr(i, (next - i)));
     }
     return vect;
 }
@@ -207,18 +208,18 @@ const Scan::Util::vector_s Scan::Util::split(const string &data,
 /// ***
 /// Indent the given string at each line break
 /// ***
-const std::string Scan::Util::indent(const string &data,
-                                     const uint &tab_size,
-                                     const bool skip_first) {
-    if (tab_size == NULL)
+const std::string scan::Util::indent(const uint &t_size,
+                                     const string &t_data,
+                                     const bool t_skip_first) {
+    if (t_size == NULL)
     {
-        throw NullArgEx("tab_size");
+        throw NullArgEx("t_size");
     }
 
-    const string tab_buff(tab_size, ' ');
-    const string eol{ (data.find(CRLF) > 0) ? CRLF : LF };
+    const string tab_buff(t_size, ' ');
+    const string eol{ (t_data.find(CRLF) > 0) ? CRLF : LF };
 
-    const vector_s vect{ split(data, eol) };
+    const vector_s vect{ split(t_data, eol) };
     const size_t length{ vect.size() };
 
     std::stringstream ss;
@@ -227,7 +228,7 @@ const std::string Scan::Util::indent(const string &data,
     for (size_t i{ 0 }; i < length; i++)
     {
         // Don't indent first line
-        if (skip_first && (i == 0))
+        if (t_skip_first && (i == 0))
         {
             ss << vect[i] << LF;
             continue;
@@ -246,37 +247,37 @@ const std::string Scan::Util::indent(const string &data,
 /// ***
 /// Convert a long long into a string
 /// ***
-const std::string Scan::Util::itos(const llong &num)
+const std::string scan::Util::itos(const llong &t_num)
 {
-    if (num == NULL)
+    if (t_num == NULL)
     {
-        throw NullArgEx("num");
+        throw NullArgEx("t_num");
     }
-    return std::to_string(num);
+    return std::to_string(t_num);
 }
 
 /// ***
 /// Strip all instance of a character from a string
 /// ***
-const std::string Scan::Util::strip(const string &data, const char &match_ch,
-                                                        const bool &space) {
-    if (match_ch == static_cast<char>(NULL))
+const std::string scan::Util::strip(const string &t_data, const char &t_ch,
+                                                          const bool &t_space) {
+    if (t_ch == static_cast<char>(NULL))
     {
-        throw NullArgEx("ch");
+        throw NullArgEx("t_ch");
     }
     std::stringstream ss;
 
-    for (const char &ch : data)
+    for (const char &ch : t_data)
     {
         // Insert all other chars into stream
-        if (ch != match_ch)
+        if (ch != t_ch)
         {
             ss << ch;
             continue;
         }
 
-        // Replace char parameter with SPACE char
-        if (space)
+        // Replace <match_ch> with SPACE char
+        if (t_space)
         {
             ss << ' ';
         }
@@ -287,52 +288,59 @@ const std::string Scan::Util::strip(const string &data, const char &match_ch,
 /// ***
 /// Transform string characters to their lowercase equivalent
 /// ***
-const std::string Scan::Util::to_lower(const string &data)
+const std::string scan::Util::to_lower(const string &t_data)
 {
-    string clone(data);
+    string clone{ t_data };
     std::transform(clone.begin(), clone.end(), clone.begin(), std::tolower);
+
     return clone;
 }
 
 /// ***
 /// Transform UTF-16 encoded string to UTF-8 encoding
 /// ***
-const std::string Scan::Util::utf8(const wstring &data_w)
+const std::string scan::Util::utf8(const wstring &t_wdata)
 {
-    if (data_w.empty())
+    if (t_wdata.empty())
     {
         return string();
     }
-    const int len_w{ static_cast<int>(data_w.size()) };
+    const int len_w{ static_cast<int>(t_wdata.size()) };
 
     // Calculate required length
-    const int len = WideCharToMultiByte(CP_UTF8, 0, &data_w[0], len_w, NULL,
-                                                                0, NULL, NULL);
+    const int len
+    {
+        WideCharToMultiByte(CP_UTF8, 0, &t_wdata[0], len_w, nullptr, 0, nullptr,
+                                                                        nullptr)
+    };
+
     string data(len, 0);
+    char *data_ptr{ &data[0] };
 
     // Populate UTF-8 string
-    WideCharToMultiByte(CP_UTF8, 0, data_w.c_str(), len_w, &data[0], len,
-                                                           NULL, NULL);
+    WideCharToMultiByte(CP_UTF8, 0, t_wdata.c_str(), len_w, data_ptr, len,
+                                                                      nullptr,
+                                                                      nullptr);
     return data;
 }
 
 /// ***
 /// Print message and determine output stream based on color
 /// ***
-void Scan::Util::print(const FgColor &fg, const string &msg)
+void scan::Util::print(const FgColor &t_fg, const string &t_msg)
 {
     // Determine standard stream for output
-    std::ostream &os{ (fg == FgColor::cyan) ? std::cout : std::cerr };
+    std::ostream &os{ (t_fg == FgColor::cyan) ? std::cout : std::cerr };
 
     // Virtual terminal sequences disabled
     if (!vt_enabled.get())
     {
-        os << m_icons.at(fg) << " " << msg << LF;
+        os << m_icons.at(t_fg) << " " << t_msg << LF;
         return;
     }
 
     // Write color sequence to output stream
-    switch (fg)
+    switch (t_fg)
     {
         case FgColor::cyan:
             os << CYAN;
@@ -344,26 +352,27 @@ void Scan::Util::print(const FgColor &fg, const string &msg)
             os << YELLOW;
             break;
     }
-    os << m_icons.at(fg) << RESET << " " << msg << LF;
+    os << m_icons.at(t_fg) << RESET << " " << t_msg << LF;
 }
 
 /// ***
 /// Transform UTF-8 encoded string to UTF-16 encoding
 /// ***
-const std::wstring Scan::Util::utf16(const string &data)
+const std::wstring scan::Util::utf16(const string &t_data)
 {
-    if (data.empty())
+    if (t_data.empty())
     {
         return wstring();
     }
-    const int len{ static_cast<int>(data.size()) };
-    const char *ptr{ &data[0] };
+
+    const char *data_ptr{ &t_data[0] };
+    const int len{ static_cast<int>(t_data.size()) };
 
     // Calculate required length
-    int len_w{ MultiByteToWideChar(CP_UTF8, 0, ptr, len, NULL, 0) };
-    wstring data_w(len_w, 0);
+    int len_w{ MultiByteToWideChar(CP_UTF8, 0, data_ptr, len, nullptr, 0) };
+    wstring wdata(len_w, 0);
 
     // Populate UTF-16 string
-    MultiByteToWideChar(CP_UTF8, 0, ptr, len, &data_w[0], len_w);
-    return data_w;
+    MultiByteToWideChar(CP_UTF8, 0, data_ptr, len, &wdata[0], len_w);
+    return wdata;
 }


### PR DESCRIPTION
Updated naming convention for parameter names to be prefixed with `t_` .
Updated naming convention for namespace names to begin with a lowercase character.
Removed unnecessary `this->` pointer qualifications.
Other small formatting changes.